### PR TITLE
#53 trap non-zero returns, and stop

### DIFF
--- a/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_amgeo.py
+++ b/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_amgeo.py
@@ -227,7 +227,7 @@ def _create_container(
 
 def gleanerio(context, mode, source):
     ## ------------   Create
-
+    returnCode = 0
     get_dagster_logger().info(f"Gleanerio mode: {str(mode)}")
 
     if str(mode) == "gleaner":
@@ -277,7 +277,9 @@ def gleanerio(context, mode, source):
         Entrypoint = "nabu"
         # LOGFILE = 'log_nabu.txt'  # only used for local log file writing
     else:
-        return 1
+
+        returnCode = 1
+        return returnCode
 
     # from docker0dagster
     run_container_context = DockerContainerContext.create_for_run(
@@ -430,13 +432,23 @@ def gleanerio(context, mode, source):
         # container.start()
         # client.api.start(container=container.id)
         ## start is not working
-
-        for line in container.logs(stdout=True, stderr=True, stream=True, follow=True):
-            get_dagster_logger().debug(line)  # noqa: T201
+        try:
+            for line in container.logs(stdout=True, stderr=True, stream=True, follow=True):
+                get_dagster_logger().debug(line)  # noqa: T201
+        except docker.errors.APIError as ex:
+            get_dagster_logger().info(f"watch container logs failed Docker API ISSUE: ", ex)
+            returnCode = 1
+        except Exception as ex:
+            get_dagster_logger().info(f"watch container logs failed other issue: ", ex)
+            returnCode = 1
 
         # ## ------------  Wait expect 200
+        # we want to get the logs, no matter what, so do not exit, yet.
+        ## or should logs be moved into finally?
+        ### in which case they need to be methods that don't send back errors.
         exit_status = container.wait()["StatusCode"]
         get_dagster_logger().info(f"Container Wait Exit status:  {exit_status}")
+        returnCode = exit_status
 
 
 
@@ -444,7 +456,7 @@ def gleanerio(context, mode, source):
         ## ------------  Copy logs  expect 200
 
 
-        c = container.logs(stdout=True, stderr=True, stream=False, follow=True).decode('latin-1')
+        c = container.logs(stdout=True, stderr=True, stream=False, follow=False).decode('latin-1')
 
         # write to s3
 
@@ -489,65 +501,72 @@ def gleanerio(context, mode, source):
        #      i+=1
 
        # s3loader(r.read().decode('latin-1'), NAME)
-        s3loader(r.read(), f"{source}_{str(mode)}_runlogs")
+
     finally:
         if (not DEBUG) :
-            if (cid):
-                url = URL + 'containers/' + cid
-                req = request.Request(url, method="DELETE")
-                req.add_header('X-API-Key', APIKEY)
-                # req.add_header('content-type', 'application/json')
-                req.add_header('accept', 'application/json')
-                r = request.urlopen(req)
-                print(r.status)
+            # if (cid):
+            #     url = URL + 'containers/' + cid
+            #     req = request.Request(url, method="DELETE")
+            #     req.add_header('X-API-Key', APIKEY)
+            #     # req.add_header('content-type', 'application/json')
+            #     req.add_header('accept', 'application/json')
+            #     r = request.urlopen(req)
+            #     print(r.status)
+            #     get_dagster_logger().info(f"Container Remove: {str(r.status)}")
+            # else:
+            #     get_dagster_logger().info(f"Container Not created, so not removed.")
+            if (container):
+                container.remove(force=True)
                 get_dagster_logger().info(f"Container Remove: {str(r.status)}")
             else:
                 get_dagster_logger().info(f"Container Not created, so not removed.")
         else:
             get_dagster_logger().info(f"Container NOT Remove: DEBUG ENABLED")
 
-
-    return 0
+    if (returnCode != 0):
+        get_dagster_logger().info(f"Gleaner/Nabu container non-zero exit code. See logs in S3")
+        raise Exception("Gleaner/Nabu container non-zero exit code. See logs in S3")
+    return returnCode
 
 @op
-def amgeo_gleaner(context):
+def amgeo_gleaner(context)-> str:
     returned_value = gleanerio(context, ("gleaner"), "amgeo")
     r = str('returned value:{}'.format(returned_value))
     get_dagster_logger().info(f"Gleaner notes are  {r} ")
     return r
 
 @op
-def amgeo_nabu_prune(context, msg: str):
+def amgeo_nabu_prune(context, msg: str)-> str:
     returned_value = gleanerio(context,("nabu"), "amgeo")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def amgeo_nabuprov(context, msg: str):
+def amgeo_nabuprov(context, msg: str)-> str:
     returned_value = gleanerio(context,("prov"), "amgeo")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def amgeo_nabuorg(context, msg: str):
+def amgeo_nabuorg(context, msg: str)-> str:
     returned_value = gleanerio(context,("orgs"), "amgeo")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def amgeo_naburelease(context, msg: str):
+def amgeo_naburelease(context, msg: str) -> str:
     returned_value = gleanerio(context,("release"), "amgeo")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 @op
-def amgeo_uploadrelease(context, msg: str):
+def amgeo_uploadrelease(context, msg: str) -> str:
     returned_value = postRelease("amgeo")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 
 @op
-def amgeo_missingreport_s3(context, msg: str):
+def amgeo_missingreport_s3(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="amgeo")
     source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -562,7 +581,7 @@ def amgeo_missingreport_s3(context, msg: str):
     s3Minio.putReportFile(bucket, source_name, "missing_report_s3.json", report)
     return msg + r
 @op
-def amgeo_missingreport_graph(context, msg: str):
+def amgeo_missingreport_graph(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="amgeo")
     source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -581,7 +600,7 @@ def amgeo_missingreport_graph(context, msg: str):
 
     return msg + r
 @op
-def amgeo_graph_reports(context, msg: str):
+def amgeo_graph_reports(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="amgeo")
     #source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -601,7 +620,7 @@ def amgeo_graph_reports(context, msg: str):
     return msg + r
 
 @op
-def amgeo_identifier_stats(context, msg: str):
+def amgeo_identifier_stats(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="amgeo")
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
     bucket = GLEANER_MINIO_BUCKET
@@ -614,7 +633,8 @@ def amgeo_identifier_stats(context, msg: str):
     s3Minio.putReportFile(bucket, source_name, "identifier_stats.json", report)
     return msg + r
 
-def amgeo_bucket_urls(context, msg: str):
+@op()
+def amgeo_bucket_urls(context, msg: str) -> str:
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
     bucket = GLEANER_MINIO_BUCKET
     source_name = "amgeo"
@@ -648,7 +668,7 @@ def harvest_amgeo():
     report_ms3 = amgeo_missingreport_s3(harvest)
     report_idstat = amgeo_identifier_stats(report_ms3)
     # for some reason, this causes a msg parameter missing
-   # report_bucketurl = amgeo_bucket_urls(report_idstat)
+    report_bucketurl = amgeo_bucket_urls(report_idstat)
 
     #report1 = missingreport_s3(harvest, source="amgeo")
     load_release = amgeo_naburelease(harvest)

--- a/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_aquadocs.py
+++ b/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_aquadocs.py
@@ -227,7 +227,7 @@ def _create_container(
 
 def gleanerio(context, mode, source):
     ## ------------   Create
-
+    returnCode = 0
     get_dagster_logger().info(f"Gleanerio mode: {str(mode)}")
 
     if str(mode) == "gleaner":
@@ -277,7 +277,9 @@ def gleanerio(context, mode, source):
         Entrypoint = "nabu"
         # LOGFILE = 'log_nabu.txt'  # only used for local log file writing
     else:
-        return 1
+
+        returnCode = 1
+        return returnCode
 
     # from docker0dagster
     run_container_context = DockerContainerContext.create_for_run(
@@ -430,13 +432,23 @@ def gleanerio(context, mode, source):
         # container.start()
         # client.api.start(container=container.id)
         ## start is not working
-
-        for line in container.logs(stdout=True, stderr=True, stream=True, follow=True):
-            get_dagster_logger().debug(line)  # noqa: T201
+        try:
+            for line in container.logs(stdout=True, stderr=True, stream=True, follow=True):
+                get_dagster_logger().debug(line)  # noqa: T201
+        except docker.errors.APIError as ex:
+            get_dagster_logger().info(f"watch container logs failed Docker API ISSUE: ", ex)
+            returnCode = 1
+        except Exception as ex:
+            get_dagster_logger().info(f"watch container logs failed other issue: ", ex)
+            returnCode = 1
 
         # ## ------------  Wait expect 200
+        # we want to get the logs, no matter what, so do not exit, yet.
+        ## or should logs be moved into finally?
+        ### in which case they need to be methods that don't send back errors.
         exit_status = container.wait()["StatusCode"]
         get_dagster_logger().info(f"Container Wait Exit status:  {exit_status}")
+        returnCode = exit_status
 
 
 
@@ -444,7 +456,7 @@ def gleanerio(context, mode, source):
         ## ------------  Copy logs  expect 200
 
 
-        c = container.logs(stdout=True, stderr=True, stream=False, follow=True).decode('latin-1')
+        c = container.logs(stdout=True, stderr=True, stream=False, follow=False).decode('latin-1')
 
         # write to s3
 
@@ -489,65 +501,72 @@ def gleanerio(context, mode, source):
        #      i+=1
 
        # s3loader(r.read().decode('latin-1'), NAME)
-        s3loader(r.read(), f"{source}_{str(mode)}_runlogs")
+
     finally:
         if (not DEBUG) :
-            if (cid):
-                url = URL + 'containers/' + cid
-                req = request.Request(url, method="DELETE")
-                req.add_header('X-API-Key', APIKEY)
-                # req.add_header('content-type', 'application/json')
-                req.add_header('accept', 'application/json')
-                r = request.urlopen(req)
-                print(r.status)
+            # if (cid):
+            #     url = URL + 'containers/' + cid
+            #     req = request.Request(url, method="DELETE")
+            #     req.add_header('X-API-Key', APIKEY)
+            #     # req.add_header('content-type', 'application/json')
+            #     req.add_header('accept', 'application/json')
+            #     r = request.urlopen(req)
+            #     print(r.status)
+            #     get_dagster_logger().info(f"Container Remove: {str(r.status)}")
+            # else:
+            #     get_dagster_logger().info(f"Container Not created, so not removed.")
+            if (container):
+                container.remove(force=True)
                 get_dagster_logger().info(f"Container Remove: {str(r.status)}")
             else:
                 get_dagster_logger().info(f"Container Not created, so not removed.")
         else:
             get_dagster_logger().info(f"Container NOT Remove: DEBUG ENABLED")
 
-
-    return 0
+    if (returnCode != 0):
+        get_dagster_logger().info(f"Gleaner/Nabu container non-zero exit code. See logs in S3")
+        raise Exception("Gleaner/Nabu container non-zero exit code. See logs in S3")
+    return returnCode
 
 @op
-def aquadocs_gleaner(context):
+def aquadocs_gleaner(context)-> str:
     returned_value = gleanerio(context, ("gleaner"), "aquadocs")
     r = str('returned value:{}'.format(returned_value))
     get_dagster_logger().info(f"Gleaner notes are  {r} ")
     return r
 
 @op
-def aquadocs_nabu_prune(context, msg: str):
+def aquadocs_nabu_prune(context, msg: str)-> str:
     returned_value = gleanerio(context,("nabu"), "aquadocs")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def aquadocs_nabuprov(context, msg: str):
+def aquadocs_nabuprov(context, msg: str)-> str:
     returned_value = gleanerio(context,("prov"), "aquadocs")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def aquadocs_nabuorg(context, msg: str):
+def aquadocs_nabuorg(context, msg: str)-> str:
     returned_value = gleanerio(context,("orgs"), "aquadocs")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def aquadocs_naburelease(context, msg: str):
+def aquadocs_naburelease(context, msg: str) -> str:
     returned_value = gleanerio(context,("release"), "aquadocs")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 @op
-def aquadocs_uploadrelease(context, msg: str):
+def aquadocs_uploadrelease(context, msg: str) -> str:
     returned_value = postRelease("aquadocs")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 
 @op
-def aquadocs_missingreport_s3(context, msg: str):
+def aquadocs_missingreport_s3(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="aquadocs")
     source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -562,7 +581,7 @@ def aquadocs_missingreport_s3(context, msg: str):
     s3Minio.putReportFile(bucket, source_name, "missing_report_s3.json", report)
     return msg + r
 @op
-def aquadocs_missingreport_graph(context, msg: str):
+def aquadocs_missingreport_graph(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="aquadocs")
     source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -581,7 +600,7 @@ def aquadocs_missingreport_graph(context, msg: str):
 
     return msg + r
 @op
-def aquadocs_graph_reports(context, msg: str):
+def aquadocs_graph_reports(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="aquadocs")
     #source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -601,7 +620,7 @@ def aquadocs_graph_reports(context, msg: str):
     return msg + r
 
 @op
-def aquadocs_identifier_stats(context, msg: str):
+def aquadocs_identifier_stats(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="aquadocs")
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
     bucket = GLEANER_MINIO_BUCKET
@@ -614,7 +633,8 @@ def aquadocs_identifier_stats(context, msg: str):
     s3Minio.putReportFile(bucket, source_name, "identifier_stats.json", report)
     return msg + r
 
-def aquadocs_bucket_urls(context, msg: str):
+@op()
+def aquadocs_bucket_urls(context, msg: str) -> str:
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
     bucket = GLEANER_MINIO_BUCKET
     source_name = "aquadocs"
@@ -648,7 +668,7 @@ def harvest_aquadocs():
     report_ms3 = aquadocs_missingreport_s3(harvest)
     report_idstat = aquadocs_identifier_stats(report_ms3)
     # for some reason, this causes a msg parameter missing
-   # report_bucketurl = aquadocs_bucket_urls(report_idstat)
+    report_bucketurl = aquadocs_bucket_urls(report_idstat)
 
     #report1 = missingreport_s3(harvest, source="aquadocs")
     load_release = aquadocs_naburelease(harvest)

--- a/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_balto.py
+++ b/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_balto.py
@@ -227,7 +227,7 @@ def _create_container(
 
 def gleanerio(context, mode, source):
     ## ------------   Create
-
+    returnCode = 0
     get_dagster_logger().info(f"Gleanerio mode: {str(mode)}")
 
     if str(mode) == "gleaner":
@@ -277,7 +277,9 @@ def gleanerio(context, mode, source):
         Entrypoint = "nabu"
         # LOGFILE = 'log_nabu.txt'  # only used for local log file writing
     else:
-        return 1
+
+        returnCode = 1
+        return returnCode
 
     # from docker0dagster
     run_container_context = DockerContainerContext.create_for_run(
@@ -430,13 +432,23 @@ def gleanerio(context, mode, source):
         # container.start()
         # client.api.start(container=container.id)
         ## start is not working
-
-        for line in container.logs(stdout=True, stderr=True, stream=True, follow=True):
-            get_dagster_logger().debug(line)  # noqa: T201
+        try:
+            for line in container.logs(stdout=True, stderr=True, stream=True, follow=True):
+                get_dagster_logger().debug(line)  # noqa: T201
+        except docker.errors.APIError as ex:
+            get_dagster_logger().info(f"watch container logs failed Docker API ISSUE: ", ex)
+            returnCode = 1
+        except Exception as ex:
+            get_dagster_logger().info(f"watch container logs failed other issue: ", ex)
+            returnCode = 1
 
         # ## ------------  Wait expect 200
+        # we want to get the logs, no matter what, so do not exit, yet.
+        ## or should logs be moved into finally?
+        ### in which case they need to be methods that don't send back errors.
         exit_status = container.wait()["StatusCode"]
         get_dagster_logger().info(f"Container Wait Exit status:  {exit_status}")
+        returnCode = exit_status
 
 
 
@@ -444,7 +456,7 @@ def gleanerio(context, mode, source):
         ## ------------  Copy logs  expect 200
 
 
-        c = container.logs(stdout=True, stderr=True, stream=False, follow=True).decode('latin-1')
+        c = container.logs(stdout=True, stderr=True, stream=False, follow=False).decode('latin-1')
 
         # write to s3
 
@@ -489,65 +501,72 @@ def gleanerio(context, mode, source):
        #      i+=1
 
        # s3loader(r.read().decode('latin-1'), NAME)
-        s3loader(r.read(), f"{source}_{str(mode)}_runlogs")
+
     finally:
         if (not DEBUG) :
-            if (cid):
-                url = URL + 'containers/' + cid
-                req = request.Request(url, method="DELETE")
-                req.add_header('X-API-Key', APIKEY)
-                # req.add_header('content-type', 'application/json')
-                req.add_header('accept', 'application/json')
-                r = request.urlopen(req)
-                print(r.status)
+            # if (cid):
+            #     url = URL + 'containers/' + cid
+            #     req = request.Request(url, method="DELETE")
+            #     req.add_header('X-API-Key', APIKEY)
+            #     # req.add_header('content-type', 'application/json')
+            #     req.add_header('accept', 'application/json')
+            #     r = request.urlopen(req)
+            #     print(r.status)
+            #     get_dagster_logger().info(f"Container Remove: {str(r.status)}")
+            # else:
+            #     get_dagster_logger().info(f"Container Not created, so not removed.")
+            if (container):
+                container.remove(force=True)
                 get_dagster_logger().info(f"Container Remove: {str(r.status)}")
             else:
                 get_dagster_logger().info(f"Container Not created, so not removed.")
         else:
             get_dagster_logger().info(f"Container NOT Remove: DEBUG ENABLED")
 
-
-    return 0
+    if (returnCode != 0):
+        get_dagster_logger().info(f"Gleaner/Nabu container non-zero exit code. See logs in S3")
+        raise Exception("Gleaner/Nabu container non-zero exit code. See logs in S3")
+    return returnCode
 
 @op
-def balto_gleaner(context):
+def balto_gleaner(context)-> str:
     returned_value = gleanerio(context, ("gleaner"), "balto")
     r = str('returned value:{}'.format(returned_value))
     get_dagster_logger().info(f"Gleaner notes are  {r} ")
     return r
 
 @op
-def balto_nabu_prune(context, msg: str):
+def balto_nabu_prune(context, msg: str)-> str:
     returned_value = gleanerio(context,("nabu"), "balto")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def balto_nabuprov(context, msg: str):
+def balto_nabuprov(context, msg: str)-> str:
     returned_value = gleanerio(context,("prov"), "balto")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def balto_nabuorg(context, msg: str):
+def balto_nabuorg(context, msg: str)-> str:
     returned_value = gleanerio(context,("orgs"), "balto")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def balto_naburelease(context, msg: str):
+def balto_naburelease(context, msg: str) -> str:
     returned_value = gleanerio(context,("release"), "balto")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 @op
-def balto_uploadrelease(context, msg: str):
+def balto_uploadrelease(context, msg: str) -> str:
     returned_value = postRelease("balto")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 
 @op
-def balto_missingreport_s3(context, msg: str):
+def balto_missingreport_s3(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="balto")
     source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -562,7 +581,7 @@ def balto_missingreport_s3(context, msg: str):
     s3Minio.putReportFile(bucket, source_name, "missing_report_s3.json", report)
     return msg + r
 @op
-def balto_missingreport_graph(context, msg: str):
+def balto_missingreport_graph(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="balto")
     source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -581,7 +600,7 @@ def balto_missingreport_graph(context, msg: str):
 
     return msg + r
 @op
-def balto_graph_reports(context, msg: str):
+def balto_graph_reports(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="balto")
     #source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -601,7 +620,7 @@ def balto_graph_reports(context, msg: str):
     return msg + r
 
 @op
-def balto_identifier_stats(context, msg: str):
+def balto_identifier_stats(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="balto")
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
     bucket = GLEANER_MINIO_BUCKET
@@ -614,7 +633,8 @@ def balto_identifier_stats(context, msg: str):
     s3Minio.putReportFile(bucket, source_name, "identifier_stats.json", report)
     return msg + r
 
-def balto_bucket_urls(context, msg: str):
+@op()
+def balto_bucket_urls(context, msg: str) -> str:
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
     bucket = GLEANER_MINIO_BUCKET
     source_name = "balto"
@@ -648,7 +668,7 @@ def harvest_balto():
     report_ms3 = balto_missingreport_s3(harvest)
     report_idstat = balto_identifier_stats(report_ms3)
     # for some reason, this causes a msg parameter missing
-   # report_bucketurl = balto_bucket_urls(report_idstat)
+    report_bucketurl = balto_bucket_urls(report_idstat)
 
     #report1 = missingreport_s3(harvest, source="balto")
     load_release = balto_naburelease(harvest)

--- a/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_bcodmo.py
+++ b/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_bcodmo.py
@@ -227,7 +227,7 @@ def _create_container(
 
 def gleanerio(context, mode, source):
     ## ------------   Create
-
+    returnCode = 0
     get_dagster_logger().info(f"Gleanerio mode: {str(mode)}")
 
     if str(mode) == "gleaner":
@@ -277,7 +277,9 @@ def gleanerio(context, mode, source):
         Entrypoint = "nabu"
         # LOGFILE = 'log_nabu.txt'  # only used for local log file writing
     else:
-        return 1
+
+        returnCode = 1
+        return returnCode
 
     # from docker0dagster
     run_container_context = DockerContainerContext.create_for_run(
@@ -430,13 +432,23 @@ def gleanerio(context, mode, source):
         # container.start()
         # client.api.start(container=container.id)
         ## start is not working
-
-        for line in container.logs(stdout=True, stderr=True, stream=True, follow=True):
-            get_dagster_logger().debug(line)  # noqa: T201
+        try:
+            for line in container.logs(stdout=True, stderr=True, stream=True, follow=True):
+                get_dagster_logger().debug(line)  # noqa: T201
+        except docker.errors.APIError as ex:
+            get_dagster_logger().info(f"watch container logs failed Docker API ISSUE: ", ex)
+            returnCode = 1
+        except Exception as ex:
+            get_dagster_logger().info(f"watch container logs failed other issue: ", ex)
+            returnCode = 1
 
         # ## ------------  Wait expect 200
+        # we want to get the logs, no matter what, so do not exit, yet.
+        ## or should logs be moved into finally?
+        ### in which case they need to be methods that don't send back errors.
         exit_status = container.wait()["StatusCode"]
         get_dagster_logger().info(f"Container Wait Exit status:  {exit_status}")
+        returnCode = exit_status
 
 
 
@@ -444,7 +456,7 @@ def gleanerio(context, mode, source):
         ## ------------  Copy logs  expect 200
 
 
-        c = container.logs(stdout=True, stderr=True, stream=False, follow=True).decode('latin-1')
+        c = container.logs(stdout=True, stderr=True, stream=False, follow=False).decode('latin-1')
 
         # write to s3
 
@@ -489,65 +501,72 @@ def gleanerio(context, mode, source):
        #      i+=1
 
        # s3loader(r.read().decode('latin-1'), NAME)
-        s3loader(r.read(), f"{source}_{str(mode)}_runlogs")
+
     finally:
         if (not DEBUG) :
-            if (cid):
-                url = URL + 'containers/' + cid
-                req = request.Request(url, method="DELETE")
-                req.add_header('X-API-Key', APIKEY)
-                # req.add_header('content-type', 'application/json')
-                req.add_header('accept', 'application/json')
-                r = request.urlopen(req)
-                print(r.status)
+            # if (cid):
+            #     url = URL + 'containers/' + cid
+            #     req = request.Request(url, method="DELETE")
+            #     req.add_header('X-API-Key', APIKEY)
+            #     # req.add_header('content-type', 'application/json')
+            #     req.add_header('accept', 'application/json')
+            #     r = request.urlopen(req)
+            #     print(r.status)
+            #     get_dagster_logger().info(f"Container Remove: {str(r.status)}")
+            # else:
+            #     get_dagster_logger().info(f"Container Not created, so not removed.")
+            if (container):
+                container.remove(force=True)
                 get_dagster_logger().info(f"Container Remove: {str(r.status)}")
             else:
                 get_dagster_logger().info(f"Container Not created, so not removed.")
         else:
             get_dagster_logger().info(f"Container NOT Remove: DEBUG ENABLED")
 
-
-    return 0
+    if (returnCode != 0):
+        get_dagster_logger().info(f"Gleaner/Nabu container non-zero exit code. See logs in S3")
+        raise Exception("Gleaner/Nabu container non-zero exit code. See logs in S3")
+    return returnCode
 
 @op
-def bcodmo_gleaner(context):
+def bcodmo_gleaner(context)-> str:
     returned_value = gleanerio(context, ("gleaner"), "bcodmo")
     r = str('returned value:{}'.format(returned_value))
     get_dagster_logger().info(f"Gleaner notes are  {r} ")
     return r
 
 @op
-def bcodmo_nabu_prune(context, msg: str):
+def bcodmo_nabu_prune(context, msg: str)-> str:
     returned_value = gleanerio(context,("nabu"), "bcodmo")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def bcodmo_nabuprov(context, msg: str):
+def bcodmo_nabuprov(context, msg: str)-> str:
     returned_value = gleanerio(context,("prov"), "bcodmo")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def bcodmo_nabuorg(context, msg: str):
+def bcodmo_nabuorg(context, msg: str)-> str:
     returned_value = gleanerio(context,("orgs"), "bcodmo")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def bcodmo_naburelease(context, msg: str):
+def bcodmo_naburelease(context, msg: str) -> str:
     returned_value = gleanerio(context,("release"), "bcodmo")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 @op
-def bcodmo_uploadrelease(context, msg: str):
+def bcodmo_uploadrelease(context, msg: str) -> str:
     returned_value = postRelease("bcodmo")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 
 @op
-def bcodmo_missingreport_s3(context, msg: str):
+def bcodmo_missingreport_s3(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="bcodmo")
     source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -562,7 +581,7 @@ def bcodmo_missingreport_s3(context, msg: str):
     s3Minio.putReportFile(bucket, source_name, "missing_report_s3.json", report)
     return msg + r
 @op
-def bcodmo_missingreport_graph(context, msg: str):
+def bcodmo_missingreport_graph(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="bcodmo")
     source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -581,7 +600,7 @@ def bcodmo_missingreport_graph(context, msg: str):
 
     return msg + r
 @op
-def bcodmo_graph_reports(context, msg: str):
+def bcodmo_graph_reports(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="bcodmo")
     #source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -601,7 +620,7 @@ def bcodmo_graph_reports(context, msg: str):
     return msg + r
 
 @op
-def bcodmo_identifier_stats(context, msg: str):
+def bcodmo_identifier_stats(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="bcodmo")
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
     bucket = GLEANER_MINIO_BUCKET
@@ -614,7 +633,8 @@ def bcodmo_identifier_stats(context, msg: str):
     s3Minio.putReportFile(bucket, source_name, "identifier_stats.json", report)
     return msg + r
 
-def bcodmo_bucket_urls(context, msg: str):
+@op()
+def bcodmo_bucket_urls(context, msg: str) -> str:
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
     bucket = GLEANER_MINIO_BUCKET
     source_name = "bcodmo"
@@ -648,7 +668,7 @@ def harvest_bcodmo():
     report_ms3 = bcodmo_missingreport_s3(harvest)
     report_idstat = bcodmo_identifier_stats(report_ms3)
     # for some reason, this causes a msg parameter missing
-   # report_bucketurl = bcodmo_bucket_urls(report_idstat)
+    report_bucketurl = bcodmo_bucket_urls(report_idstat)
 
     #report1 = missingreport_s3(harvest, source="bcodmo")
     load_release = bcodmo_naburelease(harvest)

--- a/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_cchdo.py
+++ b/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_cchdo.py
@@ -227,7 +227,7 @@ def _create_container(
 
 def gleanerio(context, mode, source):
     ## ------------   Create
-
+    returnCode = 0
     get_dagster_logger().info(f"Gleanerio mode: {str(mode)}")
 
     if str(mode) == "gleaner":
@@ -277,7 +277,9 @@ def gleanerio(context, mode, source):
         Entrypoint = "nabu"
         # LOGFILE = 'log_nabu.txt'  # only used for local log file writing
     else:
-        return 1
+
+        returnCode = 1
+        return returnCode
 
     # from docker0dagster
     run_container_context = DockerContainerContext.create_for_run(
@@ -430,13 +432,23 @@ def gleanerio(context, mode, source):
         # container.start()
         # client.api.start(container=container.id)
         ## start is not working
-
-        for line in container.logs(stdout=True, stderr=True, stream=True, follow=True):
-            get_dagster_logger().debug(line)  # noqa: T201
+        try:
+            for line in container.logs(stdout=True, stderr=True, stream=True, follow=True):
+                get_dagster_logger().debug(line)  # noqa: T201
+        except docker.errors.APIError as ex:
+            get_dagster_logger().info(f"watch container logs failed Docker API ISSUE: ", ex)
+            returnCode = 1
+        except Exception as ex:
+            get_dagster_logger().info(f"watch container logs failed other issue: ", ex)
+            returnCode = 1
 
         # ## ------------  Wait expect 200
+        # we want to get the logs, no matter what, so do not exit, yet.
+        ## or should logs be moved into finally?
+        ### in which case they need to be methods that don't send back errors.
         exit_status = container.wait()["StatusCode"]
         get_dagster_logger().info(f"Container Wait Exit status:  {exit_status}")
+        returnCode = exit_status
 
 
 
@@ -444,7 +456,7 @@ def gleanerio(context, mode, source):
         ## ------------  Copy logs  expect 200
 
 
-        c = container.logs(stdout=True, stderr=True, stream=False, follow=True).decode('latin-1')
+        c = container.logs(stdout=True, stderr=True, stream=False, follow=False).decode('latin-1')
 
         # write to s3
 
@@ -489,65 +501,72 @@ def gleanerio(context, mode, source):
        #      i+=1
 
        # s3loader(r.read().decode('latin-1'), NAME)
-        s3loader(r.read(), f"{source}_{str(mode)}_runlogs")
+
     finally:
         if (not DEBUG) :
-            if (cid):
-                url = URL + 'containers/' + cid
-                req = request.Request(url, method="DELETE")
-                req.add_header('X-API-Key', APIKEY)
-                # req.add_header('content-type', 'application/json')
-                req.add_header('accept', 'application/json')
-                r = request.urlopen(req)
-                print(r.status)
+            # if (cid):
+            #     url = URL + 'containers/' + cid
+            #     req = request.Request(url, method="DELETE")
+            #     req.add_header('X-API-Key', APIKEY)
+            #     # req.add_header('content-type', 'application/json')
+            #     req.add_header('accept', 'application/json')
+            #     r = request.urlopen(req)
+            #     print(r.status)
+            #     get_dagster_logger().info(f"Container Remove: {str(r.status)}")
+            # else:
+            #     get_dagster_logger().info(f"Container Not created, so not removed.")
+            if (container):
+                container.remove(force=True)
                 get_dagster_logger().info(f"Container Remove: {str(r.status)}")
             else:
                 get_dagster_logger().info(f"Container Not created, so not removed.")
         else:
             get_dagster_logger().info(f"Container NOT Remove: DEBUG ENABLED")
 
-
-    return 0
+    if (returnCode != 0):
+        get_dagster_logger().info(f"Gleaner/Nabu container non-zero exit code. See logs in S3")
+        raise Exception("Gleaner/Nabu container non-zero exit code. See logs in S3")
+    return returnCode
 
 @op
-def cchdo_gleaner(context):
+def cchdo_gleaner(context)-> str:
     returned_value = gleanerio(context, ("gleaner"), "cchdo")
     r = str('returned value:{}'.format(returned_value))
     get_dagster_logger().info(f"Gleaner notes are  {r} ")
     return r
 
 @op
-def cchdo_nabu_prune(context, msg: str):
+def cchdo_nabu_prune(context, msg: str)-> str:
     returned_value = gleanerio(context,("nabu"), "cchdo")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def cchdo_nabuprov(context, msg: str):
+def cchdo_nabuprov(context, msg: str)-> str:
     returned_value = gleanerio(context,("prov"), "cchdo")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def cchdo_nabuorg(context, msg: str):
+def cchdo_nabuorg(context, msg: str)-> str:
     returned_value = gleanerio(context,("orgs"), "cchdo")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def cchdo_naburelease(context, msg: str):
+def cchdo_naburelease(context, msg: str) -> str:
     returned_value = gleanerio(context,("release"), "cchdo")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 @op
-def cchdo_uploadrelease(context, msg: str):
+def cchdo_uploadrelease(context, msg: str) -> str:
     returned_value = postRelease("cchdo")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 
 @op
-def cchdo_missingreport_s3(context, msg: str):
+def cchdo_missingreport_s3(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="cchdo")
     source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -562,7 +581,7 @@ def cchdo_missingreport_s3(context, msg: str):
     s3Minio.putReportFile(bucket, source_name, "missing_report_s3.json", report)
     return msg + r
 @op
-def cchdo_missingreport_graph(context, msg: str):
+def cchdo_missingreport_graph(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="cchdo")
     source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -581,7 +600,7 @@ def cchdo_missingreport_graph(context, msg: str):
 
     return msg + r
 @op
-def cchdo_graph_reports(context, msg: str):
+def cchdo_graph_reports(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="cchdo")
     #source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -601,7 +620,7 @@ def cchdo_graph_reports(context, msg: str):
     return msg + r
 
 @op
-def cchdo_identifier_stats(context, msg: str):
+def cchdo_identifier_stats(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="cchdo")
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
     bucket = GLEANER_MINIO_BUCKET
@@ -614,7 +633,8 @@ def cchdo_identifier_stats(context, msg: str):
     s3Minio.putReportFile(bucket, source_name, "identifier_stats.json", report)
     return msg + r
 
-def cchdo_bucket_urls(context, msg: str):
+@op()
+def cchdo_bucket_urls(context, msg: str) -> str:
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
     bucket = GLEANER_MINIO_BUCKET
     source_name = "cchdo"
@@ -648,7 +668,7 @@ def harvest_cchdo():
     report_ms3 = cchdo_missingreport_s3(harvest)
     report_idstat = cchdo_identifier_stats(report_ms3)
     # for some reason, this causes a msg parameter missing
-   # report_bucketurl = cchdo_bucket_urls(report_idstat)
+    report_bucketurl = cchdo_bucket_urls(report_idstat)
 
     #report1 = missingreport_s3(harvest, source="cchdo")
     load_release = cchdo_naburelease(harvest)

--- a/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_designsafe.py
+++ b/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_designsafe.py
@@ -227,7 +227,7 @@ def _create_container(
 
 def gleanerio(context, mode, source):
     ## ------------   Create
-
+    returnCode = 0
     get_dagster_logger().info(f"Gleanerio mode: {str(mode)}")
 
     if str(mode) == "gleaner":
@@ -277,7 +277,9 @@ def gleanerio(context, mode, source):
         Entrypoint = "nabu"
         # LOGFILE = 'log_nabu.txt'  # only used for local log file writing
     else:
-        return 1
+
+        returnCode = 1
+        return returnCode
 
     # from docker0dagster
     run_container_context = DockerContainerContext.create_for_run(
@@ -430,13 +432,23 @@ def gleanerio(context, mode, source):
         # container.start()
         # client.api.start(container=container.id)
         ## start is not working
-
-        for line in container.logs(stdout=True, stderr=True, stream=True, follow=True):
-            get_dagster_logger().debug(line)  # noqa: T201
+        try:
+            for line in container.logs(stdout=True, stderr=True, stream=True, follow=True):
+                get_dagster_logger().debug(line)  # noqa: T201
+        except docker.errors.APIError as ex:
+            get_dagster_logger().info(f"watch container logs failed Docker API ISSUE: ", ex)
+            returnCode = 1
+        except Exception as ex:
+            get_dagster_logger().info(f"watch container logs failed other issue: ", ex)
+            returnCode = 1
 
         # ## ------------  Wait expect 200
+        # we want to get the logs, no matter what, so do not exit, yet.
+        ## or should logs be moved into finally?
+        ### in which case they need to be methods that don't send back errors.
         exit_status = container.wait()["StatusCode"]
         get_dagster_logger().info(f"Container Wait Exit status:  {exit_status}")
+        returnCode = exit_status
 
 
 
@@ -444,7 +456,7 @@ def gleanerio(context, mode, source):
         ## ------------  Copy logs  expect 200
 
 
-        c = container.logs(stdout=True, stderr=True, stream=False, follow=True).decode('latin-1')
+        c = container.logs(stdout=True, stderr=True, stream=False, follow=False).decode('latin-1')
 
         # write to s3
 
@@ -489,65 +501,72 @@ def gleanerio(context, mode, source):
        #      i+=1
 
        # s3loader(r.read().decode('latin-1'), NAME)
-        s3loader(r.read(), f"{source}_{str(mode)}_runlogs")
+
     finally:
         if (not DEBUG) :
-            if (cid):
-                url = URL + 'containers/' + cid
-                req = request.Request(url, method="DELETE")
-                req.add_header('X-API-Key', APIKEY)
-                # req.add_header('content-type', 'application/json')
-                req.add_header('accept', 'application/json')
-                r = request.urlopen(req)
-                print(r.status)
+            # if (cid):
+            #     url = URL + 'containers/' + cid
+            #     req = request.Request(url, method="DELETE")
+            #     req.add_header('X-API-Key', APIKEY)
+            #     # req.add_header('content-type', 'application/json')
+            #     req.add_header('accept', 'application/json')
+            #     r = request.urlopen(req)
+            #     print(r.status)
+            #     get_dagster_logger().info(f"Container Remove: {str(r.status)}")
+            # else:
+            #     get_dagster_logger().info(f"Container Not created, so not removed.")
+            if (container):
+                container.remove(force=True)
                 get_dagster_logger().info(f"Container Remove: {str(r.status)}")
             else:
                 get_dagster_logger().info(f"Container Not created, so not removed.")
         else:
             get_dagster_logger().info(f"Container NOT Remove: DEBUG ENABLED")
 
-
-    return 0
+    if (returnCode != 0):
+        get_dagster_logger().info(f"Gleaner/Nabu container non-zero exit code. See logs in S3")
+        raise Exception("Gleaner/Nabu container non-zero exit code. See logs in S3")
+    return returnCode
 
 @op
-def designsafe_gleaner(context):
+def designsafe_gleaner(context)-> str:
     returned_value = gleanerio(context, ("gleaner"), "designsafe")
     r = str('returned value:{}'.format(returned_value))
     get_dagster_logger().info(f"Gleaner notes are  {r} ")
     return r
 
 @op
-def designsafe_nabu_prune(context, msg: str):
+def designsafe_nabu_prune(context, msg: str)-> str:
     returned_value = gleanerio(context,("nabu"), "designsafe")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def designsafe_nabuprov(context, msg: str):
+def designsafe_nabuprov(context, msg: str)-> str:
     returned_value = gleanerio(context,("prov"), "designsafe")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def designsafe_nabuorg(context, msg: str):
+def designsafe_nabuorg(context, msg: str)-> str:
     returned_value = gleanerio(context,("orgs"), "designsafe")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def designsafe_naburelease(context, msg: str):
+def designsafe_naburelease(context, msg: str) -> str:
     returned_value = gleanerio(context,("release"), "designsafe")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 @op
-def designsafe_uploadrelease(context, msg: str):
+def designsafe_uploadrelease(context, msg: str) -> str:
     returned_value = postRelease("designsafe")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 
 @op
-def designsafe_missingreport_s3(context, msg: str):
+def designsafe_missingreport_s3(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="designsafe")
     source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -562,7 +581,7 @@ def designsafe_missingreport_s3(context, msg: str):
     s3Minio.putReportFile(bucket, source_name, "missing_report_s3.json", report)
     return msg + r
 @op
-def designsafe_missingreport_graph(context, msg: str):
+def designsafe_missingreport_graph(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="designsafe")
     source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -581,7 +600,7 @@ def designsafe_missingreport_graph(context, msg: str):
 
     return msg + r
 @op
-def designsafe_graph_reports(context, msg: str):
+def designsafe_graph_reports(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="designsafe")
     #source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -601,7 +620,7 @@ def designsafe_graph_reports(context, msg: str):
     return msg + r
 
 @op
-def designsafe_identifier_stats(context, msg: str):
+def designsafe_identifier_stats(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="designsafe")
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
     bucket = GLEANER_MINIO_BUCKET
@@ -614,7 +633,8 @@ def designsafe_identifier_stats(context, msg: str):
     s3Minio.putReportFile(bucket, source_name, "identifier_stats.json", report)
     return msg + r
 
-def designsafe_bucket_urls(context, msg: str):
+@op()
+def designsafe_bucket_urls(context, msg: str) -> str:
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
     bucket = GLEANER_MINIO_BUCKET
     source_name = "designsafe"
@@ -648,7 +668,7 @@ def harvest_designsafe():
     report_ms3 = designsafe_missingreport_s3(harvest)
     report_idstat = designsafe_identifier_stats(report_ms3)
     # for some reason, this causes a msg parameter missing
-   # report_bucketurl = designsafe_bucket_urls(report_idstat)
+    report_bucketurl = designsafe_bucket_urls(report_idstat)
 
     #report1 = missingreport_s3(harvest, source="designsafe")
     load_release = designsafe_naburelease(harvest)

--- a/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_earthchem.py
+++ b/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_earthchem.py
@@ -227,7 +227,7 @@ def _create_container(
 
 def gleanerio(context, mode, source):
     ## ------------   Create
-
+    returnCode = 0
     get_dagster_logger().info(f"Gleanerio mode: {str(mode)}")
 
     if str(mode) == "gleaner":
@@ -277,7 +277,9 @@ def gleanerio(context, mode, source):
         Entrypoint = "nabu"
         # LOGFILE = 'log_nabu.txt'  # only used for local log file writing
     else:
-        return 1
+
+        returnCode = 1
+        return returnCode
 
     # from docker0dagster
     run_container_context = DockerContainerContext.create_for_run(
@@ -430,13 +432,23 @@ def gleanerio(context, mode, source):
         # container.start()
         # client.api.start(container=container.id)
         ## start is not working
-
-        for line in container.logs(stdout=True, stderr=True, stream=True, follow=True):
-            get_dagster_logger().debug(line)  # noqa: T201
+        try:
+            for line in container.logs(stdout=True, stderr=True, stream=True, follow=True):
+                get_dagster_logger().debug(line)  # noqa: T201
+        except docker.errors.APIError as ex:
+            get_dagster_logger().info(f"watch container logs failed Docker API ISSUE: ", ex)
+            returnCode = 1
+        except Exception as ex:
+            get_dagster_logger().info(f"watch container logs failed other issue: ", ex)
+            returnCode = 1
 
         # ## ------------  Wait expect 200
+        # we want to get the logs, no matter what, so do not exit, yet.
+        ## or should logs be moved into finally?
+        ### in which case they need to be methods that don't send back errors.
         exit_status = container.wait()["StatusCode"]
         get_dagster_logger().info(f"Container Wait Exit status:  {exit_status}")
+        returnCode = exit_status
 
 
 
@@ -444,7 +456,7 @@ def gleanerio(context, mode, source):
         ## ------------  Copy logs  expect 200
 
 
-        c = container.logs(stdout=True, stderr=True, stream=False, follow=True).decode('latin-1')
+        c = container.logs(stdout=True, stderr=True, stream=False, follow=False).decode('latin-1')
 
         # write to s3
 
@@ -489,65 +501,72 @@ def gleanerio(context, mode, source):
        #      i+=1
 
        # s3loader(r.read().decode('latin-1'), NAME)
-        s3loader(r.read(), f"{source}_{str(mode)}_runlogs")
+
     finally:
         if (not DEBUG) :
-            if (cid):
-                url = URL + 'containers/' + cid
-                req = request.Request(url, method="DELETE")
-                req.add_header('X-API-Key', APIKEY)
-                # req.add_header('content-type', 'application/json')
-                req.add_header('accept', 'application/json')
-                r = request.urlopen(req)
-                print(r.status)
+            # if (cid):
+            #     url = URL + 'containers/' + cid
+            #     req = request.Request(url, method="DELETE")
+            #     req.add_header('X-API-Key', APIKEY)
+            #     # req.add_header('content-type', 'application/json')
+            #     req.add_header('accept', 'application/json')
+            #     r = request.urlopen(req)
+            #     print(r.status)
+            #     get_dagster_logger().info(f"Container Remove: {str(r.status)}")
+            # else:
+            #     get_dagster_logger().info(f"Container Not created, so not removed.")
+            if (container):
+                container.remove(force=True)
                 get_dagster_logger().info(f"Container Remove: {str(r.status)}")
             else:
                 get_dagster_logger().info(f"Container Not created, so not removed.")
         else:
             get_dagster_logger().info(f"Container NOT Remove: DEBUG ENABLED")
 
-
-    return 0
+    if (returnCode != 0):
+        get_dagster_logger().info(f"Gleaner/Nabu container non-zero exit code. See logs in S3")
+        raise Exception("Gleaner/Nabu container non-zero exit code. See logs in S3")
+    return returnCode
 
 @op
-def earthchem_gleaner(context):
+def earthchem_gleaner(context)-> str:
     returned_value = gleanerio(context, ("gleaner"), "earthchem")
     r = str('returned value:{}'.format(returned_value))
     get_dagster_logger().info(f"Gleaner notes are  {r} ")
     return r
 
 @op
-def earthchem_nabu_prune(context, msg: str):
+def earthchem_nabu_prune(context, msg: str)-> str:
     returned_value = gleanerio(context,("nabu"), "earthchem")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def earthchem_nabuprov(context, msg: str):
+def earthchem_nabuprov(context, msg: str)-> str:
     returned_value = gleanerio(context,("prov"), "earthchem")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def earthchem_nabuorg(context, msg: str):
+def earthchem_nabuorg(context, msg: str)-> str:
     returned_value = gleanerio(context,("orgs"), "earthchem")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def earthchem_naburelease(context, msg: str):
+def earthchem_naburelease(context, msg: str) -> str:
     returned_value = gleanerio(context,("release"), "earthchem")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 @op
-def earthchem_uploadrelease(context, msg: str):
+def earthchem_uploadrelease(context, msg: str) -> str:
     returned_value = postRelease("earthchem")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 
 @op
-def earthchem_missingreport_s3(context, msg: str):
+def earthchem_missingreport_s3(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="earthchem")
     source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -562,7 +581,7 @@ def earthchem_missingreport_s3(context, msg: str):
     s3Minio.putReportFile(bucket, source_name, "missing_report_s3.json", report)
     return msg + r
 @op
-def earthchem_missingreport_graph(context, msg: str):
+def earthchem_missingreport_graph(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="earthchem")
     source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -581,7 +600,7 @@ def earthchem_missingreport_graph(context, msg: str):
 
     return msg + r
 @op
-def earthchem_graph_reports(context, msg: str):
+def earthchem_graph_reports(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="earthchem")
     #source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -601,7 +620,7 @@ def earthchem_graph_reports(context, msg: str):
     return msg + r
 
 @op
-def earthchem_identifier_stats(context, msg: str):
+def earthchem_identifier_stats(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="earthchem")
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
     bucket = GLEANER_MINIO_BUCKET
@@ -614,7 +633,8 @@ def earthchem_identifier_stats(context, msg: str):
     s3Minio.putReportFile(bucket, source_name, "identifier_stats.json", report)
     return msg + r
 
-def earthchem_bucket_urls(context, msg: str):
+@op()
+def earthchem_bucket_urls(context, msg: str) -> str:
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
     bucket = GLEANER_MINIO_BUCKET
     source_name = "earthchem"
@@ -648,7 +668,7 @@ def harvest_earthchem():
     report_ms3 = earthchem_missingreport_s3(harvest)
     report_idstat = earthchem_identifier_stats(report_ms3)
     # for some reason, this causes a msg parameter missing
-   # report_bucketurl = earthchem_bucket_urls(report_idstat)
+    report_bucketurl = earthchem_bucket_urls(report_idstat)
 
     #report1 = missingreport_s3(harvest, source="earthchem")
     load_release = earthchem_naburelease(harvest)

--- a/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_edi.py
+++ b/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_edi.py
@@ -227,7 +227,7 @@ def _create_container(
 
 def gleanerio(context, mode, source):
     ## ------------   Create
-
+    returnCode = 0
     get_dagster_logger().info(f"Gleanerio mode: {str(mode)}")
 
     if str(mode) == "gleaner":
@@ -277,7 +277,9 @@ def gleanerio(context, mode, source):
         Entrypoint = "nabu"
         # LOGFILE = 'log_nabu.txt'  # only used for local log file writing
     else:
-        return 1
+
+        returnCode = 1
+        return returnCode
 
     # from docker0dagster
     run_container_context = DockerContainerContext.create_for_run(
@@ -430,13 +432,23 @@ def gleanerio(context, mode, source):
         # container.start()
         # client.api.start(container=container.id)
         ## start is not working
-
-        for line in container.logs(stdout=True, stderr=True, stream=True, follow=True):
-            get_dagster_logger().debug(line)  # noqa: T201
+        try:
+            for line in container.logs(stdout=True, stderr=True, stream=True, follow=True):
+                get_dagster_logger().debug(line)  # noqa: T201
+        except docker.errors.APIError as ex:
+            get_dagster_logger().info(f"watch container logs failed Docker API ISSUE: ", ex)
+            returnCode = 1
+        except Exception as ex:
+            get_dagster_logger().info(f"watch container logs failed other issue: ", ex)
+            returnCode = 1
 
         # ## ------------  Wait expect 200
+        # we want to get the logs, no matter what, so do not exit, yet.
+        ## or should logs be moved into finally?
+        ### in which case they need to be methods that don't send back errors.
         exit_status = container.wait()["StatusCode"]
         get_dagster_logger().info(f"Container Wait Exit status:  {exit_status}")
+        returnCode = exit_status
 
 
 
@@ -444,7 +456,7 @@ def gleanerio(context, mode, source):
         ## ------------  Copy logs  expect 200
 
 
-        c = container.logs(stdout=True, stderr=True, stream=False, follow=True).decode('latin-1')
+        c = container.logs(stdout=True, stderr=True, stream=False, follow=False).decode('latin-1')
 
         # write to s3
 
@@ -489,65 +501,72 @@ def gleanerio(context, mode, source):
        #      i+=1
 
        # s3loader(r.read().decode('latin-1'), NAME)
-        s3loader(r.read(), f"{source}_{str(mode)}_runlogs")
+
     finally:
         if (not DEBUG) :
-            if (cid):
-                url = URL + 'containers/' + cid
-                req = request.Request(url, method="DELETE")
-                req.add_header('X-API-Key', APIKEY)
-                # req.add_header('content-type', 'application/json')
-                req.add_header('accept', 'application/json')
-                r = request.urlopen(req)
-                print(r.status)
+            # if (cid):
+            #     url = URL + 'containers/' + cid
+            #     req = request.Request(url, method="DELETE")
+            #     req.add_header('X-API-Key', APIKEY)
+            #     # req.add_header('content-type', 'application/json')
+            #     req.add_header('accept', 'application/json')
+            #     r = request.urlopen(req)
+            #     print(r.status)
+            #     get_dagster_logger().info(f"Container Remove: {str(r.status)}")
+            # else:
+            #     get_dagster_logger().info(f"Container Not created, so not removed.")
+            if (container):
+                container.remove(force=True)
                 get_dagster_logger().info(f"Container Remove: {str(r.status)}")
             else:
                 get_dagster_logger().info(f"Container Not created, so not removed.")
         else:
             get_dagster_logger().info(f"Container NOT Remove: DEBUG ENABLED")
 
-
-    return 0
+    if (returnCode != 0):
+        get_dagster_logger().info(f"Gleaner/Nabu container non-zero exit code. See logs in S3")
+        raise Exception("Gleaner/Nabu container non-zero exit code. See logs in S3")
+    return returnCode
 
 @op
-def edi_gleaner(context):
+def edi_gleaner(context)-> str:
     returned_value = gleanerio(context, ("gleaner"), "edi")
     r = str('returned value:{}'.format(returned_value))
     get_dagster_logger().info(f"Gleaner notes are  {r} ")
     return r
 
 @op
-def edi_nabu_prune(context, msg: str):
+def edi_nabu_prune(context, msg: str)-> str:
     returned_value = gleanerio(context,("nabu"), "edi")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def edi_nabuprov(context, msg: str):
+def edi_nabuprov(context, msg: str)-> str:
     returned_value = gleanerio(context,("prov"), "edi")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def edi_nabuorg(context, msg: str):
+def edi_nabuorg(context, msg: str)-> str:
     returned_value = gleanerio(context,("orgs"), "edi")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def edi_naburelease(context, msg: str):
+def edi_naburelease(context, msg: str) -> str:
     returned_value = gleanerio(context,("release"), "edi")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 @op
-def edi_uploadrelease(context, msg: str):
+def edi_uploadrelease(context, msg: str) -> str:
     returned_value = postRelease("edi")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 
 @op
-def edi_missingreport_s3(context, msg: str):
+def edi_missingreport_s3(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="edi")
     source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -562,7 +581,7 @@ def edi_missingreport_s3(context, msg: str):
     s3Minio.putReportFile(bucket, source_name, "missing_report_s3.json", report)
     return msg + r
 @op
-def edi_missingreport_graph(context, msg: str):
+def edi_missingreport_graph(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="edi")
     source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -581,7 +600,7 @@ def edi_missingreport_graph(context, msg: str):
 
     return msg + r
 @op
-def edi_graph_reports(context, msg: str):
+def edi_graph_reports(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="edi")
     #source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -601,7 +620,7 @@ def edi_graph_reports(context, msg: str):
     return msg + r
 
 @op
-def edi_identifier_stats(context, msg: str):
+def edi_identifier_stats(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="edi")
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
     bucket = GLEANER_MINIO_BUCKET
@@ -614,7 +633,8 @@ def edi_identifier_stats(context, msg: str):
     s3Minio.putReportFile(bucket, source_name, "identifier_stats.json", report)
     return msg + r
 
-def edi_bucket_urls(context, msg: str):
+@op()
+def edi_bucket_urls(context, msg: str) -> str:
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
     bucket = GLEANER_MINIO_BUCKET
     source_name = "edi"
@@ -648,7 +668,7 @@ def harvest_edi():
     report_ms3 = edi_missingreport_s3(harvest)
     report_idstat = edi_identifier_stats(report_ms3)
     # for some reason, this causes a msg parameter missing
-   # report_bucketurl = edi_bucket_urls(report_idstat)
+    report_bucketurl = edi_bucket_urls(report_idstat)
 
     #report1 = missingreport_s3(harvest, source="edi")
     load_release = edi_naburelease(harvest)

--- a/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_geocodes_demo_datasets.py
+++ b/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_geocodes_demo_datasets.py
@@ -227,7 +227,7 @@ def _create_container(
 
 def gleanerio(context, mode, source):
     ## ------------   Create
-
+    returnCode = 0
     get_dagster_logger().info(f"Gleanerio mode: {str(mode)}")
 
     if str(mode) == "gleaner":
@@ -277,7 +277,9 @@ def gleanerio(context, mode, source):
         Entrypoint = "nabu"
         # LOGFILE = 'log_nabu.txt'  # only used for local log file writing
     else:
-        return 1
+
+        returnCode = 1
+        return returnCode
 
     # from docker0dagster
     run_container_context = DockerContainerContext.create_for_run(
@@ -430,13 +432,23 @@ def gleanerio(context, mode, source):
         # container.start()
         # client.api.start(container=container.id)
         ## start is not working
-
-        for line in container.logs(stdout=True, stderr=True, stream=True, follow=True):
-            get_dagster_logger().debug(line)  # noqa: T201
+        try:
+            for line in container.logs(stdout=True, stderr=True, stream=True, follow=True):
+                get_dagster_logger().debug(line)  # noqa: T201
+        except docker.errors.APIError as ex:
+            get_dagster_logger().info(f"watch container logs failed Docker API ISSUE: ", ex)
+            returnCode = 1
+        except Exception as ex:
+            get_dagster_logger().info(f"watch container logs failed other issue: ", ex)
+            returnCode = 1
 
         # ## ------------  Wait expect 200
+        # we want to get the logs, no matter what, so do not exit, yet.
+        ## or should logs be moved into finally?
+        ### in which case they need to be methods that don't send back errors.
         exit_status = container.wait()["StatusCode"]
         get_dagster_logger().info(f"Container Wait Exit status:  {exit_status}")
+        returnCode = exit_status
 
 
 
@@ -444,7 +456,7 @@ def gleanerio(context, mode, source):
         ## ------------  Copy logs  expect 200
 
 
-        c = container.logs(stdout=True, stderr=True, stream=False, follow=True).decode('latin-1')
+        c = container.logs(stdout=True, stderr=True, stream=False, follow=False).decode('latin-1')
 
         # write to s3
 
@@ -489,65 +501,72 @@ def gleanerio(context, mode, source):
        #      i+=1
 
        # s3loader(r.read().decode('latin-1'), NAME)
-        s3loader(r.read(), f"{source}_{str(mode)}_runlogs")
+
     finally:
         if (not DEBUG) :
-            if (cid):
-                url = URL + 'containers/' + cid
-                req = request.Request(url, method="DELETE")
-                req.add_header('X-API-Key', APIKEY)
-                # req.add_header('content-type', 'application/json')
-                req.add_header('accept', 'application/json')
-                r = request.urlopen(req)
-                print(r.status)
+            # if (cid):
+            #     url = URL + 'containers/' + cid
+            #     req = request.Request(url, method="DELETE")
+            #     req.add_header('X-API-Key', APIKEY)
+            #     # req.add_header('content-type', 'application/json')
+            #     req.add_header('accept', 'application/json')
+            #     r = request.urlopen(req)
+            #     print(r.status)
+            #     get_dagster_logger().info(f"Container Remove: {str(r.status)}")
+            # else:
+            #     get_dagster_logger().info(f"Container Not created, so not removed.")
+            if (container):
+                container.remove(force=True)
                 get_dagster_logger().info(f"Container Remove: {str(r.status)}")
             else:
                 get_dagster_logger().info(f"Container Not created, so not removed.")
         else:
             get_dagster_logger().info(f"Container NOT Remove: DEBUG ENABLED")
 
-
-    return 0
+    if (returnCode != 0):
+        get_dagster_logger().info(f"Gleaner/Nabu container non-zero exit code. See logs in S3")
+        raise Exception("Gleaner/Nabu container non-zero exit code. See logs in S3")
+    return returnCode
 
 @op
-def geocodes_demo_datasets_gleaner(context):
+def geocodes_demo_datasets_gleaner(context)-> str:
     returned_value = gleanerio(context, ("gleaner"), "geocodes_demo_datasets")
     r = str('returned value:{}'.format(returned_value))
     get_dagster_logger().info(f"Gleaner notes are  {r} ")
     return r
 
 @op
-def geocodes_demo_datasets_nabu_prune(context, msg: str):
+def geocodes_demo_datasets_nabu_prune(context, msg: str)-> str:
     returned_value = gleanerio(context,("nabu"), "geocodes_demo_datasets")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def geocodes_demo_datasets_nabuprov(context, msg: str):
+def geocodes_demo_datasets_nabuprov(context, msg: str)-> str:
     returned_value = gleanerio(context,("prov"), "geocodes_demo_datasets")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def geocodes_demo_datasets_nabuorg(context, msg: str):
+def geocodes_demo_datasets_nabuorg(context, msg: str)-> str:
     returned_value = gleanerio(context,("orgs"), "geocodes_demo_datasets")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def geocodes_demo_datasets_naburelease(context, msg: str):
+def geocodes_demo_datasets_naburelease(context, msg: str) -> str:
     returned_value = gleanerio(context,("release"), "geocodes_demo_datasets")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 @op
-def geocodes_demo_datasets_uploadrelease(context, msg: str):
+def geocodes_demo_datasets_uploadrelease(context, msg: str) -> str:
     returned_value = postRelease("geocodes_demo_datasets")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 
 @op
-def geocodes_demo_datasets_missingreport_s3(context, msg: str):
+def geocodes_demo_datasets_missingreport_s3(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="geocodes_demo_datasets")
     source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -562,7 +581,7 @@ def geocodes_demo_datasets_missingreport_s3(context, msg: str):
     s3Minio.putReportFile(bucket, source_name, "missing_report_s3.json", report)
     return msg + r
 @op
-def geocodes_demo_datasets_missingreport_graph(context, msg: str):
+def geocodes_demo_datasets_missingreport_graph(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="geocodes_demo_datasets")
     source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -581,7 +600,7 @@ def geocodes_demo_datasets_missingreport_graph(context, msg: str):
 
     return msg + r
 @op
-def geocodes_demo_datasets_graph_reports(context, msg: str):
+def geocodes_demo_datasets_graph_reports(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="geocodes_demo_datasets")
     #source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -601,7 +620,7 @@ def geocodes_demo_datasets_graph_reports(context, msg: str):
     return msg + r
 
 @op
-def geocodes_demo_datasets_identifier_stats(context, msg: str):
+def geocodes_demo_datasets_identifier_stats(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="geocodes_demo_datasets")
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
     bucket = GLEANER_MINIO_BUCKET
@@ -614,7 +633,8 @@ def geocodes_demo_datasets_identifier_stats(context, msg: str):
     s3Minio.putReportFile(bucket, source_name, "identifier_stats.json", report)
     return msg + r
 
-def geocodes_demo_datasets_bucket_urls(context, msg: str):
+@op()
+def geocodes_demo_datasets_bucket_urls(context, msg: str) -> str:
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
     bucket = GLEANER_MINIO_BUCKET
     source_name = "geocodes_demo_datasets"
@@ -648,7 +668,7 @@ def harvest_geocodes_demo_datasets():
     report_ms3 = geocodes_demo_datasets_missingreport_s3(harvest)
     report_idstat = geocodes_demo_datasets_identifier_stats(report_ms3)
     # for some reason, this causes a msg parameter missing
-   # report_bucketurl = geocodes_demo_datasets_bucket_urls(report_idstat)
+    report_bucketurl = geocodes_demo_datasets_bucket_urls(report_idstat)
 
     #report1 = missingreport_s3(harvest, source="geocodes_demo_datasets")
     load_release = geocodes_demo_datasets_naburelease(harvest)

--- a/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_hydroshare.py
+++ b/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_hydroshare.py
@@ -227,7 +227,7 @@ def _create_container(
 
 def gleanerio(context, mode, source):
     ## ------------   Create
-
+    returnCode = 0
     get_dagster_logger().info(f"Gleanerio mode: {str(mode)}")
 
     if str(mode) == "gleaner":
@@ -277,7 +277,9 @@ def gleanerio(context, mode, source):
         Entrypoint = "nabu"
         # LOGFILE = 'log_nabu.txt'  # only used for local log file writing
     else:
-        return 1
+
+        returnCode = 1
+        return returnCode
 
     # from docker0dagster
     run_container_context = DockerContainerContext.create_for_run(
@@ -430,13 +432,23 @@ def gleanerio(context, mode, source):
         # container.start()
         # client.api.start(container=container.id)
         ## start is not working
-
-        for line in container.logs(stdout=True, stderr=True, stream=True, follow=True):
-            get_dagster_logger().debug(line)  # noqa: T201
+        try:
+            for line in container.logs(stdout=True, stderr=True, stream=True, follow=True):
+                get_dagster_logger().debug(line)  # noqa: T201
+        except docker.errors.APIError as ex:
+            get_dagster_logger().info(f"watch container logs failed Docker API ISSUE: ", ex)
+            returnCode = 1
+        except Exception as ex:
+            get_dagster_logger().info(f"watch container logs failed other issue: ", ex)
+            returnCode = 1
 
         # ## ------------  Wait expect 200
+        # we want to get the logs, no matter what, so do not exit, yet.
+        ## or should logs be moved into finally?
+        ### in which case they need to be methods that don't send back errors.
         exit_status = container.wait()["StatusCode"]
         get_dagster_logger().info(f"Container Wait Exit status:  {exit_status}")
+        returnCode = exit_status
 
 
 
@@ -444,7 +456,7 @@ def gleanerio(context, mode, source):
         ## ------------  Copy logs  expect 200
 
 
-        c = container.logs(stdout=True, stderr=True, stream=False, follow=True).decode('latin-1')
+        c = container.logs(stdout=True, stderr=True, stream=False, follow=False).decode('latin-1')
 
         # write to s3
 
@@ -489,65 +501,72 @@ def gleanerio(context, mode, source):
        #      i+=1
 
        # s3loader(r.read().decode('latin-1'), NAME)
-        s3loader(r.read(), f"{source}_{str(mode)}_runlogs")
+
     finally:
         if (not DEBUG) :
-            if (cid):
-                url = URL + 'containers/' + cid
-                req = request.Request(url, method="DELETE")
-                req.add_header('X-API-Key', APIKEY)
-                # req.add_header('content-type', 'application/json')
-                req.add_header('accept', 'application/json')
-                r = request.urlopen(req)
-                print(r.status)
+            # if (cid):
+            #     url = URL + 'containers/' + cid
+            #     req = request.Request(url, method="DELETE")
+            #     req.add_header('X-API-Key', APIKEY)
+            #     # req.add_header('content-type', 'application/json')
+            #     req.add_header('accept', 'application/json')
+            #     r = request.urlopen(req)
+            #     print(r.status)
+            #     get_dagster_logger().info(f"Container Remove: {str(r.status)}")
+            # else:
+            #     get_dagster_logger().info(f"Container Not created, so not removed.")
+            if (container):
+                container.remove(force=True)
                 get_dagster_logger().info(f"Container Remove: {str(r.status)}")
             else:
                 get_dagster_logger().info(f"Container Not created, so not removed.")
         else:
             get_dagster_logger().info(f"Container NOT Remove: DEBUG ENABLED")
 
-
-    return 0
+    if (returnCode != 0):
+        get_dagster_logger().info(f"Gleaner/Nabu container non-zero exit code. See logs in S3")
+        raise Exception("Gleaner/Nabu container non-zero exit code. See logs in S3")
+    return returnCode
 
 @op
-def hydroshare_gleaner(context):
+def hydroshare_gleaner(context)-> str:
     returned_value = gleanerio(context, ("gleaner"), "hydroshare")
     r = str('returned value:{}'.format(returned_value))
     get_dagster_logger().info(f"Gleaner notes are  {r} ")
     return r
 
 @op
-def hydroshare_nabu_prune(context, msg: str):
+def hydroshare_nabu_prune(context, msg: str)-> str:
     returned_value = gleanerio(context,("nabu"), "hydroshare")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def hydroshare_nabuprov(context, msg: str):
+def hydroshare_nabuprov(context, msg: str)-> str:
     returned_value = gleanerio(context,("prov"), "hydroshare")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def hydroshare_nabuorg(context, msg: str):
+def hydroshare_nabuorg(context, msg: str)-> str:
     returned_value = gleanerio(context,("orgs"), "hydroshare")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def hydroshare_naburelease(context, msg: str):
+def hydroshare_naburelease(context, msg: str) -> str:
     returned_value = gleanerio(context,("release"), "hydroshare")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 @op
-def hydroshare_uploadrelease(context, msg: str):
+def hydroshare_uploadrelease(context, msg: str) -> str:
     returned_value = postRelease("hydroshare")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 
 @op
-def hydroshare_missingreport_s3(context, msg: str):
+def hydroshare_missingreport_s3(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="hydroshare")
     source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -562,7 +581,7 @@ def hydroshare_missingreport_s3(context, msg: str):
     s3Minio.putReportFile(bucket, source_name, "missing_report_s3.json", report)
     return msg + r
 @op
-def hydroshare_missingreport_graph(context, msg: str):
+def hydroshare_missingreport_graph(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="hydroshare")
     source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -581,7 +600,7 @@ def hydroshare_missingreport_graph(context, msg: str):
 
     return msg + r
 @op
-def hydroshare_graph_reports(context, msg: str):
+def hydroshare_graph_reports(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="hydroshare")
     #source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -601,7 +620,7 @@ def hydroshare_graph_reports(context, msg: str):
     return msg + r
 
 @op
-def hydroshare_identifier_stats(context, msg: str):
+def hydroshare_identifier_stats(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="hydroshare")
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
     bucket = GLEANER_MINIO_BUCKET
@@ -614,7 +633,8 @@ def hydroshare_identifier_stats(context, msg: str):
     s3Minio.putReportFile(bucket, source_name, "identifier_stats.json", report)
     return msg + r
 
-def hydroshare_bucket_urls(context, msg: str):
+@op()
+def hydroshare_bucket_urls(context, msg: str) -> str:
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
     bucket = GLEANER_MINIO_BUCKET
     source_name = "hydroshare"
@@ -648,7 +668,7 @@ def harvest_hydroshare():
     report_ms3 = hydroshare_missingreport_s3(harvest)
     report_idstat = hydroshare_identifier_stats(report_ms3)
     # for some reason, this causes a msg parameter missing
-   # report_bucketurl = hydroshare_bucket_urls(report_idstat)
+    report_bucketurl = hydroshare_bucket_urls(report_idstat)
 
     #report1 = missingreport_s3(harvest, source="hydroshare")
     load_release = hydroshare_naburelease(harvest)

--- a/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_iedadata.py
+++ b/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_iedadata.py
@@ -227,7 +227,7 @@ def _create_container(
 
 def gleanerio(context, mode, source):
     ## ------------   Create
-
+    returnCode = 0
     get_dagster_logger().info(f"Gleanerio mode: {str(mode)}")
 
     if str(mode) == "gleaner":
@@ -277,7 +277,9 @@ def gleanerio(context, mode, source):
         Entrypoint = "nabu"
         # LOGFILE = 'log_nabu.txt'  # only used for local log file writing
     else:
-        return 1
+
+        returnCode = 1
+        return returnCode
 
     # from docker0dagster
     run_container_context = DockerContainerContext.create_for_run(
@@ -430,13 +432,23 @@ def gleanerio(context, mode, source):
         # container.start()
         # client.api.start(container=container.id)
         ## start is not working
-
-        for line in container.logs(stdout=True, stderr=True, stream=True, follow=True):
-            get_dagster_logger().debug(line)  # noqa: T201
+        try:
+            for line in container.logs(stdout=True, stderr=True, stream=True, follow=True):
+                get_dagster_logger().debug(line)  # noqa: T201
+        except docker.errors.APIError as ex:
+            get_dagster_logger().info(f"watch container logs failed Docker API ISSUE: ", ex)
+            returnCode = 1
+        except Exception as ex:
+            get_dagster_logger().info(f"watch container logs failed other issue: ", ex)
+            returnCode = 1
 
         # ## ------------  Wait expect 200
+        # we want to get the logs, no matter what, so do not exit, yet.
+        ## or should logs be moved into finally?
+        ### in which case they need to be methods that don't send back errors.
         exit_status = container.wait()["StatusCode"]
         get_dagster_logger().info(f"Container Wait Exit status:  {exit_status}")
+        returnCode = exit_status
 
 
 
@@ -444,7 +456,7 @@ def gleanerio(context, mode, source):
         ## ------------  Copy logs  expect 200
 
 
-        c = container.logs(stdout=True, stderr=True, stream=False, follow=True).decode('latin-1')
+        c = container.logs(stdout=True, stderr=True, stream=False, follow=False).decode('latin-1')
 
         # write to s3
 
@@ -489,65 +501,72 @@ def gleanerio(context, mode, source):
        #      i+=1
 
        # s3loader(r.read().decode('latin-1'), NAME)
-        s3loader(r.read(), f"{source}_{str(mode)}_runlogs")
+
     finally:
         if (not DEBUG) :
-            if (cid):
-                url = URL + 'containers/' + cid
-                req = request.Request(url, method="DELETE")
-                req.add_header('X-API-Key', APIKEY)
-                # req.add_header('content-type', 'application/json')
-                req.add_header('accept', 'application/json')
-                r = request.urlopen(req)
-                print(r.status)
+            # if (cid):
+            #     url = URL + 'containers/' + cid
+            #     req = request.Request(url, method="DELETE")
+            #     req.add_header('X-API-Key', APIKEY)
+            #     # req.add_header('content-type', 'application/json')
+            #     req.add_header('accept', 'application/json')
+            #     r = request.urlopen(req)
+            #     print(r.status)
+            #     get_dagster_logger().info(f"Container Remove: {str(r.status)}")
+            # else:
+            #     get_dagster_logger().info(f"Container Not created, so not removed.")
+            if (container):
+                container.remove(force=True)
                 get_dagster_logger().info(f"Container Remove: {str(r.status)}")
             else:
                 get_dagster_logger().info(f"Container Not created, so not removed.")
         else:
             get_dagster_logger().info(f"Container NOT Remove: DEBUG ENABLED")
 
-
-    return 0
+    if (returnCode != 0):
+        get_dagster_logger().info(f"Gleaner/Nabu container non-zero exit code. See logs in S3")
+        raise Exception("Gleaner/Nabu container non-zero exit code. See logs in S3")
+    return returnCode
 
 @op
-def iedadata_gleaner(context):
+def iedadata_gleaner(context)-> str:
     returned_value = gleanerio(context, ("gleaner"), "iedadata")
     r = str('returned value:{}'.format(returned_value))
     get_dagster_logger().info(f"Gleaner notes are  {r} ")
     return r
 
 @op
-def iedadata_nabu_prune(context, msg: str):
+def iedadata_nabu_prune(context, msg: str)-> str:
     returned_value = gleanerio(context,("nabu"), "iedadata")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def iedadata_nabuprov(context, msg: str):
+def iedadata_nabuprov(context, msg: str)-> str:
     returned_value = gleanerio(context,("prov"), "iedadata")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def iedadata_nabuorg(context, msg: str):
+def iedadata_nabuorg(context, msg: str)-> str:
     returned_value = gleanerio(context,("orgs"), "iedadata")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def iedadata_naburelease(context, msg: str):
+def iedadata_naburelease(context, msg: str) -> str:
     returned_value = gleanerio(context,("release"), "iedadata")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 @op
-def iedadata_uploadrelease(context, msg: str):
+def iedadata_uploadrelease(context, msg: str) -> str:
     returned_value = postRelease("iedadata")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 
 @op
-def iedadata_missingreport_s3(context, msg: str):
+def iedadata_missingreport_s3(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="iedadata")
     source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -562,7 +581,7 @@ def iedadata_missingreport_s3(context, msg: str):
     s3Minio.putReportFile(bucket, source_name, "missing_report_s3.json", report)
     return msg + r
 @op
-def iedadata_missingreport_graph(context, msg: str):
+def iedadata_missingreport_graph(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="iedadata")
     source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -581,7 +600,7 @@ def iedadata_missingreport_graph(context, msg: str):
 
     return msg + r
 @op
-def iedadata_graph_reports(context, msg: str):
+def iedadata_graph_reports(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="iedadata")
     #source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -601,7 +620,7 @@ def iedadata_graph_reports(context, msg: str):
     return msg + r
 
 @op
-def iedadata_identifier_stats(context, msg: str):
+def iedadata_identifier_stats(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="iedadata")
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
     bucket = GLEANER_MINIO_BUCKET
@@ -614,7 +633,8 @@ def iedadata_identifier_stats(context, msg: str):
     s3Minio.putReportFile(bucket, source_name, "identifier_stats.json", report)
     return msg + r
 
-def iedadata_bucket_urls(context, msg: str):
+@op()
+def iedadata_bucket_urls(context, msg: str) -> str:
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
     bucket = GLEANER_MINIO_BUCKET
     source_name = "iedadata"
@@ -648,7 +668,7 @@ def harvest_iedadata():
     report_ms3 = iedadata_missingreport_s3(harvest)
     report_idstat = iedadata_identifier_stats(report_ms3)
     # for some reason, this causes a msg parameter missing
-   # report_bucketurl = iedadata_bucket_urls(report_idstat)
+    report_bucketurl = iedadata_bucket_urls(report_idstat)
 
     #report1 = missingreport_s3(harvest, source="iedadata")
     load_release = iedadata_naburelease(harvest)

--- a/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_linkedearth.py
+++ b/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_linkedearth.py
@@ -227,7 +227,7 @@ def _create_container(
 
 def gleanerio(context, mode, source):
     ## ------------   Create
-
+    returnCode = 0
     get_dagster_logger().info(f"Gleanerio mode: {str(mode)}")
 
     if str(mode) == "gleaner":
@@ -277,7 +277,9 @@ def gleanerio(context, mode, source):
         Entrypoint = "nabu"
         # LOGFILE = 'log_nabu.txt'  # only used for local log file writing
     else:
-        return 1
+
+        returnCode = 1
+        return returnCode
 
     # from docker0dagster
     run_container_context = DockerContainerContext.create_for_run(
@@ -430,13 +432,23 @@ def gleanerio(context, mode, source):
         # container.start()
         # client.api.start(container=container.id)
         ## start is not working
-
-        for line in container.logs(stdout=True, stderr=True, stream=True, follow=True):
-            get_dagster_logger().debug(line)  # noqa: T201
+        try:
+            for line in container.logs(stdout=True, stderr=True, stream=True, follow=True):
+                get_dagster_logger().debug(line)  # noqa: T201
+        except docker.errors.APIError as ex:
+            get_dagster_logger().info(f"watch container logs failed Docker API ISSUE: ", ex)
+            returnCode = 1
+        except Exception as ex:
+            get_dagster_logger().info(f"watch container logs failed other issue: ", ex)
+            returnCode = 1
 
         # ## ------------  Wait expect 200
+        # we want to get the logs, no matter what, so do not exit, yet.
+        ## or should logs be moved into finally?
+        ### in which case they need to be methods that don't send back errors.
         exit_status = container.wait()["StatusCode"]
         get_dagster_logger().info(f"Container Wait Exit status:  {exit_status}")
+        returnCode = exit_status
 
 
 
@@ -444,7 +456,7 @@ def gleanerio(context, mode, source):
         ## ------------  Copy logs  expect 200
 
 
-        c = container.logs(stdout=True, stderr=True, stream=False, follow=True).decode('latin-1')
+        c = container.logs(stdout=True, stderr=True, stream=False, follow=False).decode('latin-1')
 
         # write to s3
 
@@ -489,65 +501,72 @@ def gleanerio(context, mode, source):
        #      i+=1
 
        # s3loader(r.read().decode('latin-1'), NAME)
-        s3loader(r.read(), f"{source}_{str(mode)}_runlogs")
+
     finally:
         if (not DEBUG) :
-            if (cid):
-                url = URL + 'containers/' + cid
-                req = request.Request(url, method="DELETE")
-                req.add_header('X-API-Key', APIKEY)
-                # req.add_header('content-type', 'application/json')
-                req.add_header('accept', 'application/json')
-                r = request.urlopen(req)
-                print(r.status)
+            # if (cid):
+            #     url = URL + 'containers/' + cid
+            #     req = request.Request(url, method="DELETE")
+            #     req.add_header('X-API-Key', APIKEY)
+            #     # req.add_header('content-type', 'application/json')
+            #     req.add_header('accept', 'application/json')
+            #     r = request.urlopen(req)
+            #     print(r.status)
+            #     get_dagster_logger().info(f"Container Remove: {str(r.status)}")
+            # else:
+            #     get_dagster_logger().info(f"Container Not created, so not removed.")
+            if (container):
+                container.remove(force=True)
                 get_dagster_logger().info(f"Container Remove: {str(r.status)}")
             else:
                 get_dagster_logger().info(f"Container Not created, so not removed.")
         else:
             get_dagster_logger().info(f"Container NOT Remove: DEBUG ENABLED")
 
-
-    return 0
+    if (returnCode != 0):
+        get_dagster_logger().info(f"Gleaner/Nabu container non-zero exit code. See logs in S3")
+        raise Exception("Gleaner/Nabu container non-zero exit code. See logs in S3")
+    return returnCode
 
 @op
-def linkedearth_gleaner(context):
+def linkedearth_gleaner(context)-> str:
     returned_value = gleanerio(context, ("gleaner"), "linkedearth")
     r = str('returned value:{}'.format(returned_value))
     get_dagster_logger().info(f"Gleaner notes are  {r} ")
     return r
 
 @op
-def linkedearth_nabu_prune(context, msg: str):
+def linkedearth_nabu_prune(context, msg: str)-> str:
     returned_value = gleanerio(context,("nabu"), "linkedearth")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def linkedearth_nabuprov(context, msg: str):
+def linkedearth_nabuprov(context, msg: str)-> str:
     returned_value = gleanerio(context,("prov"), "linkedearth")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def linkedearth_nabuorg(context, msg: str):
+def linkedearth_nabuorg(context, msg: str)-> str:
     returned_value = gleanerio(context,("orgs"), "linkedearth")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def linkedearth_naburelease(context, msg: str):
+def linkedearth_naburelease(context, msg: str) -> str:
     returned_value = gleanerio(context,("release"), "linkedearth")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 @op
-def linkedearth_uploadrelease(context, msg: str):
+def linkedearth_uploadrelease(context, msg: str) -> str:
     returned_value = postRelease("linkedearth")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 
 @op
-def linkedearth_missingreport_s3(context, msg: str):
+def linkedearth_missingreport_s3(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="linkedearth")
     source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -562,7 +581,7 @@ def linkedearth_missingreport_s3(context, msg: str):
     s3Minio.putReportFile(bucket, source_name, "missing_report_s3.json", report)
     return msg + r
 @op
-def linkedearth_missingreport_graph(context, msg: str):
+def linkedearth_missingreport_graph(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="linkedearth")
     source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -581,7 +600,7 @@ def linkedearth_missingreport_graph(context, msg: str):
 
     return msg + r
 @op
-def linkedearth_graph_reports(context, msg: str):
+def linkedearth_graph_reports(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="linkedearth")
     #source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -601,7 +620,7 @@ def linkedearth_graph_reports(context, msg: str):
     return msg + r
 
 @op
-def linkedearth_identifier_stats(context, msg: str):
+def linkedearth_identifier_stats(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="linkedearth")
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
     bucket = GLEANER_MINIO_BUCKET
@@ -614,7 +633,8 @@ def linkedearth_identifier_stats(context, msg: str):
     s3Minio.putReportFile(bucket, source_name, "identifier_stats.json", report)
     return msg + r
 
-def linkedearth_bucket_urls(context, msg: str):
+@op()
+def linkedearth_bucket_urls(context, msg: str) -> str:
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
     bucket = GLEANER_MINIO_BUCKET
     source_name = "linkedearth"
@@ -648,7 +668,7 @@ def harvest_linkedearth():
     report_ms3 = linkedearth_missingreport_s3(harvest)
     report_idstat = linkedearth_identifier_stats(report_ms3)
     # for some reason, this causes a msg parameter missing
-   # report_bucketurl = linkedearth_bucket_urls(report_idstat)
+    report_bucketurl = linkedearth_bucket_urls(report_idstat)
 
     #report1 = missingreport_s3(harvest, source="linkedearth")
     load_release = linkedearth_naburelease(harvest)

--- a/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_lipdverse.py
+++ b/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_lipdverse.py
@@ -227,7 +227,7 @@ def _create_container(
 
 def gleanerio(context, mode, source):
     ## ------------   Create
-
+    returnCode = 0
     get_dagster_logger().info(f"Gleanerio mode: {str(mode)}")
 
     if str(mode) == "gleaner":
@@ -277,7 +277,9 @@ def gleanerio(context, mode, source):
         Entrypoint = "nabu"
         # LOGFILE = 'log_nabu.txt'  # only used for local log file writing
     else:
-        return 1
+
+        returnCode = 1
+        return returnCode
 
     # from docker0dagster
     run_container_context = DockerContainerContext.create_for_run(
@@ -430,13 +432,23 @@ def gleanerio(context, mode, source):
         # container.start()
         # client.api.start(container=container.id)
         ## start is not working
-
-        for line in container.logs(stdout=True, stderr=True, stream=True, follow=True):
-            get_dagster_logger().debug(line)  # noqa: T201
+        try:
+            for line in container.logs(stdout=True, stderr=True, stream=True, follow=True):
+                get_dagster_logger().debug(line)  # noqa: T201
+        except docker.errors.APIError as ex:
+            get_dagster_logger().info(f"watch container logs failed Docker API ISSUE: ", ex)
+            returnCode = 1
+        except Exception as ex:
+            get_dagster_logger().info(f"watch container logs failed other issue: ", ex)
+            returnCode = 1
 
         # ## ------------  Wait expect 200
+        # we want to get the logs, no matter what, so do not exit, yet.
+        ## or should logs be moved into finally?
+        ### in which case they need to be methods that don't send back errors.
         exit_status = container.wait()["StatusCode"]
         get_dagster_logger().info(f"Container Wait Exit status:  {exit_status}")
+        returnCode = exit_status
 
 
 
@@ -444,7 +456,7 @@ def gleanerio(context, mode, source):
         ## ------------  Copy logs  expect 200
 
 
-        c = container.logs(stdout=True, stderr=True, stream=False, follow=True).decode('latin-1')
+        c = container.logs(stdout=True, stderr=True, stream=False, follow=False).decode('latin-1')
 
         # write to s3
 
@@ -489,65 +501,72 @@ def gleanerio(context, mode, source):
        #      i+=1
 
        # s3loader(r.read().decode('latin-1'), NAME)
-        s3loader(r.read(), f"{source}_{str(mode)}_runlogs")
+
     finally:
         if (not DEBUG) :
-            if (cid):
-                url = URL + 'containers/' + cid
-                req = request.Request(url, method="DELETE")
-                req.add_header('X-API-Key', APIKEY)
-                # req.add_header('content-type', 'application/json')
-                req.add_header('accept', 'application/json')
-                r = request.urlopen(req)
-                print(r.status)
+            # if (cid):
+            #     url = URL + 'containers/' + cid
+            #     req = request.Request(url, method="DELETE")
+            #     req.add_header('X-API-Key', APIKEY)
+            #     # req.add_header('content-type', 'application/json')
+            #     req.add_header('accept', 'application/json')
+            #     r = request.urlopen(req)
+            #     print(r.status)
+            #     get_dagster_logger().info(f"Container Remove: {str(r.status)}")
+            # else:
+            #     get_dagster_logger().info(f"Container Not created, so not removed.")
+            if (container):
+                container.remove(force=True)
                 get_dagster_logger().info(f"Container Remove: {str(r.status)}")
             else:
                 get_dagster_logger().info(f"Container Not created, so not removed.")
         else:
             get_dagster_logger().info(f"Container NOT Remove: DEBUG ENABLED")
 
-
-    return 0
+    if (returnCode != 0):
+        get_dagster_logger().info(f"Gleaner/Nabu container non-zero exit code. See logs in S3")
+        raise Exception("Gleaner/Nabu container non-zero exit code. See logs in S3")
+    return returnCode
 
 @op
-def lipdverse_gleaner(context):
+def lipdverse_gleaner(context)-> str:
     returned_value = gleanerio(context, ("gleaner"), "lipdverse")
     r = str('returned value:{}'.format(returned_value))
     get_dagster_logger().info(f"Gleaner notes are  {r} ")
     return r
 
 @op
-def lipdverse_nabu_prune(context, msg: str):
+def lipdverse_nabu_prune(context, msg: str)-> str:
     returned_value = gleanerio(context,("nabu"), "lipdverse")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def lipdverse_nabuprov(context, msg: str):
+def lipdverse_nabuprov(context, msg: str)-> str:
     returned_value = gleanerio(context,("prov"), "lipdverse")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def lipdverse_nabuorg(context, msg: str):
+def lipdverse_nabuorg(context, msg: str)-> str:
     returned_value = gleanerio(context,("orgs"), "lipdverse")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def lipdverse_naburelease(context, msg: str):
+def lipdverse_naburelease(context, msg: str) -> str:
     returned_value = gleanerio(context,("release"), "lipdverse")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 @op
-def lipdverse_uploadrelease(context, msg: str):
+def lipdverse_uploadrelease(context, msg: str) -> str:
     returned_value = postRelease("lipdverse")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 
 @op
-def lipdverse_missingreport_s3(context, msg: str):
+def lipdverse_missingreport_s3(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="lipdverse")
     source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -562,7 +581,7 @@ def lipdverse_missingreport_s3(context, msg: str):
     s3Minio.putReportFile(bucket, source_name, "missing_report_s3.json", report)
     return msg + r
 @op
-def lipdverse_missingreport_graph(context, msg: str):
+def lipdverse_missingreport_graph(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="lipdverse")
     source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -581,7 +600,7 @@ def lipdverse_missingreport_graph(context, msg: str):
 
     return msg + r
 @op
-def lipdverse_graph_reports(context, msg: str):
+def lipdverse_graph_reports(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="lipdverse")
     #source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -601,7 +620,7 @@ def lipdverse_graph_reports(context, msg: str):
     return msg + r
 
 @op
-def lipdverse_identifier_stats(context, msg: str):
+def lipdverse_identifier_stats(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="lipdverse")
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
     bucket = GLEANER_MINIO_BUCKET
@@ -614,7 +633,8 @@ def lipdverse_identifier_stats(context, msg: str):
     s3Minio.putReportFile(bucket, source_name, "identifier_stats.json", report)
     return msg + r
 
-def lipdverse_bucket_urls(context, msg: str):
+@op()
+def lipdverse_bucket_urls(context, msg: str) -> str:
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
     bucket = GLEANER_MINIO_BUCKET
     source_name = "lipdverse"
@@ -648,7 +668,7 @@ def harvest_lipdverse():
     report_ms3 = lipdverse_missingreport_s3(harvest)
     report_idstat = lipdverse_identifier_stats(report_ms3)
     # for some reason, this causes a msg parameter missing
-   # report_bucketurl = lipdverse_bucket_urls(report_idstat)
+    report_bucketurl = lipdverse_bucket_urls(report_idstat)
 
     #report1 = missingreport_s3(harvest, source="lipdverse")
     load_release = lipdverse_naburelease(harvest)

--- a/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_magic.py
+++ b/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_magic.py
@@ -227,7 +227,7 @@ def _create_container(
 
 def gleanerio(context, mode, source):
     ## ------------   Create
-
+    returnCode = 0
     get_dagster_logger().info(f"Gleanerio mode: {str(mode)}")
 
     if str(mode) == "gleaner":
@@ -277,7 +277,9 @@ def gleanerio(context, mode, source):
         Entrypoint = "nabu"
         # LOGFILE = 'log_nabu.txt'  # only used for local log file writing
     else:
-        return 1
+
+        returnCode = 1
+        return returnCode
 
     # from docker0dagster
     run_container_context = DockerContainerContext.create_for_run(
@@ -430,13 +432,23 @@ def gleanerio(context, mode, source):
         # container.start()
         # client.api.start(container=container.id)
         ## start is not working
-
-        for line in container.logs(stdout=True, stderr=True, stream=True, follow=True):
-            get_dagster_logger().debug(line)  # noqa: T201
+        try:
+            for line in container.logs(stdout=True, stderr=True, stream=True, follow=True):
+                get_dagster_logger().debug(line)  # noqa: T201
+        except docker.errors.APIError as ex:
+            get_dagster_logger().info(f"watch container logs failed Docker API ISSUE: ", ex)
+            returnCode = 1
+        except Exception as ex:
+            get_dagster_logger().info(f"watch container logs failed other issue: ", ex)
+            returnCode = 1
 
         # ## ------------  Wait expect 200
+        # we want to get the logs, no matter what, so do not exit, yet.
+        ## or should logs be moved into finally?
+        ### in which case they need to be methods that don't send back errors.
         exit_status = container.wait()["StatusCode"]
         get_dagster_logger().info(f"Container Wait Exit status:  {exit_status}")
+        returnCode = exit_status
 
 
 
@@ -444,7 +456,7 @@ def gleanerio(context, mode, source):
         ## ------------  Copy logs  expect 200
 
 
-        c = container.logs(stdout=True, stderr=True, stream=False, follow=True).decode('latin-1')
+        c = container.logs(stdout=True, stderr=True, stream=False, follow=False).decode('latin-1')
 
         # write to s3
 
@@ -489,65 +501,72 @@ def gleanerio(context, mode, source):
        #      i+=1
 
        # s3loader(r.read().decode('latin-1'), NAME)
-        s3loader(r.read(), f"{source}_{str(mode)}_runlogs")
+
     finally:
         if (not DEBUG) :
-            if (cid):
-                url = URL + 'containers/' + cid
-                req = request.Request(url, method="DELETE")
-                req.add_header('X-API-Key', APIKEY)
-                # req.add_header('content-type', 'application/json')
-                req.add_header('accept', 'application/json')
-                r = request.urlopen(req)
-                print(r.status)
+            # if (cid):
+            #     url = URL + 'containers/' + cid
+            #     req = request.Request(url, method="DELETE")
+            #     req.add_header('X-API-Key', APIKEY)
+            #     # req.add_header('content-type', 'application/json')
+            #     req.add_header('accept', 'application/json')
+            #     r = request.urlopen(req)
+            #     print(r.status)
+            #     get_dagster_logger().info(f"Container Remove: {str(r.status)}")
+            # else:
+            #     get_dagster_logger().info(f"Container Not created, so not removed.")
+            if (container):
+                container.remove(force=True)
                 get_dagster_logger().info(f"Container Remove: {str(r.status)}")
             else:
                 get_dagster_logger().info(f"Container Not created, so not removed.")
         else:
             get_dagster_logger().info(f"Container NOT Remove: DEBUG ENABLED")
 
-
-    return 0
+    if (returnCode != 0):
+        get_dagster_logger().info(f"Gleaner/Nabu container non-zero exit code. See logs in S3")
+        raise Exception("Gleaner/Nabu container non-zero exit code. See logs in S3")
+    return returnCode
 
 @op
-def magic_gleaner(context):
+def magic_gleaner(context)-> str:
     returned_value = gleanerio(context, ("gleaner"), "magic")
     r = str('returned value:{}'.format(returned_value))
     get_dagster_logger().info(f"Gleaner notes are  {r} ")
     return r
 
 @op
-def magic_nabu_prune(context, msg: str):
+def magic_nabu_prune(context, msg: str)-> str:
     returned_value = gleanerio(context,("nabu"), "magic")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def magic_nabuprov(context, msg: str):
+def magic_nabuprov(context, msg: str)-> str:
     returned_value = gleanerio(context,("prov"), "magic")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def magic_nabuorg(context, msg: str):
+def magic_nabuorg(context, msg: str)-> str:
     returned_value = gleanerio(context,("orgs"), "magic")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def magic_naburelease(context, msg: str):
+def magic_naburelease(context, msg: str) -> str:
     returned_value = gleanerio(context,("release"), "magic")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 @op
-def magic_uploadrelease(context, msg: str):
+def magic_uploadrelease(context, msg: str) -> str:
     returned_value = postRelease("magic")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 
 @op
-def magic_missingreport_s3(context, msg: str):
+def magic_missingreport_s3(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="magic")
     source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -562,7 +581,7 @@ def magic_missingreport_s3(context, msg: str):
     s3Minio.putReportFile(bucket, source_name, "missing_report_s3.json", report)
     return msg + r
 @op
-def magic_missingreport_graph(context, msg: str):
+def magic_missingreport_graph(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="magic")
     source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -581,7 +600,7 @@ def magic_missingreport_graph(context, msg: str):
 
     return msg + r
 @op
-def magic_graph_reports(context, msg: str):
+def magic_graph_reports(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="magic")
     #source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -601,7 +620,7 @@ def magic_graph_reports(context, msg: str):
     return msg + r
 
 @op
-def magic_identifier_stats(context, msg: str):
+def magic_identifier_stats(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="magic")
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
     bucket = GLEANER_MINIO_BUCKET
@@ -614,7 +633,8 @@ def magic_identifier_stats(context, msg: str):
     s3Minio.putReportFile(bucket, source_name, "identifier_stats.json", report)
     return msg + r
 
-def magic_bucket_urls(context, msg: str):
+@op()
+def magic_bucket_urls(context, msg: str) -> str:
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
     bucket = GLEANER_MINIO_BUCKET
     source_name = "magic"
@@ -648,7 +668,7 @@ def harvest_magic():
     report_ms3 = magic_missingreport_s3(harvest)
     report_idstat = magic_identifier_stats(report_ms3)
     # for some reason, this causes a msg parameter missing
-   # report_bucketurl = magic_bucket_urls(report_idstat)
+    report_bucketurl = magic_bucket_urls(report_idstat)
 
     #report1 = missingreport_s3(harvest, source="magic")
     load_release = magic_naburelease(harvest)

--- a/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_neon.py
+++ b/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_neon.py
@@ -227,7 +227,7 @@ def _create_container(
 
 def gleanerio(context, mode, source):
     ## ------------   Create
-
+    returnCode = 0
     get_dagster_logger().info(f"Gleanerio mode: {str(mode)}")
 
     if str(mode) == "gleaner":
@@ -277,7 +277,9 @@ def gleanerio(context, mode, source):
         Entrypoint = "nabu"
         # LOGFILE = 'log_nabu.txt'  # only used for local log file writing
     else:
-        return 1
+
+        returnCode = 1
+        return returnCode
 
     # from docker0dagster
     run_container_context = DockerContainerContext.create_for_run(
@@ -430,13 +432,23 @@ def gleanerio(context, mode, source):
         # container.start()
         # client.api.start(container=container.id)
         ## start is not working
-
-        for line in container.logs(stdout=True, stderr=True, stream=True, follow=True):
-            get_dagster_logger().debug(line)  # noqa: T201
+        try:
+            for line in container.logs(stdout=True, stderr=True, stream=True, follow=True):
+                get_dagster_logger().debug(line)  # noqa: T201
+        except docker.errors.APIError as ex:
+            get_dagster_logger().info(f"watch container logs failed Docker API ISSUE: ", ex)
+            returnCode = 1
+        except Exception as ex:
+            get_dagster_logger().info(f"watch container logs failed other issue: ", ex)
+            returnCode = 1
 
         # ## ------------  Wait expect 200
+        # we want to get the logs, no matter what, so do not exit, yet.
+        ## or should logs be moved into finally?
+        ### in which case they need to be methods that don't send back errors.
         exit_status = container.wait()["StatusCode"]
         get_dagster_logger().info(f"Container Wait Exit status:  {exit_status}")
+        returnCode = exit_status
 
 
 
@@ -444,7 +456,7 @@ def gleanerio(context, mode, source):
         ## ------------  Copy logs  expect 200
 
 
-        c = container.logs(stdout=True, stderr=True, stream=False, follow=True).decode('latin-1')
+        c = container.logs(stdout=True, stderr=True, stream=False, follow=False).decode('latin-1')
 
         # write to s3
 
@@ -489,65 +501,72 @@ def gleanerio(context, mode, source):
        #      i+=1
 
        # s3loader(r.read().decode('latin-1'), NAME)
-        s3loader(r.read(), f"{source}_{str(mode)}_runlogs")
+
     finally:
         if (not DEBUG) :
-            if (cid):
-                url = URL + 'containers/' + cid
-                req = request.Request(url, method="DELETE")
-                req.add_header('X-API-Key', APIKEY)
-                # req.add_header('content-type', 'application/json')
-                req.add_header('accept', 'application/json')
-                r = request.urlopen(req)
-                print(r.status)
+            # if (cid):
+            #     url = URL + 'containers/' + cid
+            #     req = request.Request(url, method="DELETE")
+            #     req.add_header('X-API-Key', APIKEY)
+            #     # req.add_header('content-type', 'application/json')
+            #     req.add_header('accept', 'application/json')
+            #     r = request.urlopen(req)
+            #     print(r.status)
+            #     get_dagster_logger().info(f"Container Remove: {str(r.status)}")
+            # else:
+            #     get_dagster_logger().info(f"Container Not created, so not removed.")
+            if (container):
+                container.remove(force=True)
                 get_dagster_logger().info(f"Container Remove: {str(r.status)}")
             else:
                 get_dagster_logger().info(f"Container Not created, so not removed.")
         else:
             get_dagster_logger().info(f"Container NOT Remove: DEBUG ENABLED")
 
-
-    return 0
+    if (returnCode != 0):
+        get_dagster_logger().info(f"Gleaner/Nabu container non-zero exit code. See logs in S3")
+        raise Exception("Gleaner/Nabu container non-zero exit code. See logs in S3")
+    return returnCode
 
 @op
-def neon_gleaner(context):
+def neon_gleaner(context)-> str:
     returned_value = gleanerio(context, ("gleaner"), "neon")
     r = str('returned value:{}'.format(returned_value))
     get_dagster_logger().info(f"Gleaner notes are  {r} ")
     return r
 
 @op
-def neon_nabu_prune(context, msg: str):
+def neon_nabu_prune(context, msg: str)-> str:
     returned_value = gleanerio(context,("nabu"), "neon")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def neon_nabuprov(context, msg: str):
+def neon_nabuprov(context, msg: str)-> str:
     returned_value = gleanerio(context,("prov"), "neon")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def neon_nabuorg(context, msg: str):
+def neon_nabuorg(context, msg: str)-> str:
     returned_value = gleanerio(context,("orgs"), "neon")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def neon_naburelease(context, msg: str):
+def neon_naburelease(context, msg: str) -> str:
     returned_value = gleanerio(context,("release"), "neon")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 @op
-def neon_uploadrelease(context, msg: str):
+def neon_uploadrelease(context, msg: str) -> str:
     returned_value = postRelease("neon")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 
 @op
-def neon_missingreport_s3(context, msg: str):
+def neon_missingreport_s3(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="neon")
     source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -562,7 +581,7 @@ def neon_missingreport_s3(context, msg: str):
     s3Minio.putReportFile(bucket, source_name, "missing_report_s3.json", report)
     return msg + r
 @op
-def neon_missingreport_graph(context, msg: str):
+def neon_missingreport_graph(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="neon")
     source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -581,7 +600,7 @@ def neon_missingreport_graph(context, msg: str):
 
     return msg + r
 @op
-def neon_graph_reports(context, msg: str):
+def neon_graph_reports(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="neon")
     #source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -601,7 +620,7 @@ def neon_graph_reports(context, msg: str):
     return msg + r
 
 @op
-def neon_identifier_stats(context, msg: str):
+def neon_identifier_stats(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="neon")
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
     bucket = GLEANER_MINIO_BUCKET
@@ -614,7 +633,8 @@ def neon_identifier_stats(context, msg: str):
     s3Minio.putReportFile(bucket, source_name, "identifier_stats.json", report)
     return msg + r
 
-def neon_bucket_urls(context, msg: str):
+@op()
+def neon_bucket_urls(context, msg: str) -> str:
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
     bucket = GLEANER_MINIO_BUCKET
     source_name = "neon"
@@ -648,7 +668,7 @@ def harvest_neon():
     report_ms3 = neon_missingreport_s3(harvest)
     report_idstat = neon_identifier_stats(report_ms3)
     # for some reason, this causes a msg parameter missing
-   # report_bucketurl = neon_bucket_urls(report_idstat)
+    report_bucketurl = neon_bucket_urls(report_idstat)
 
     #report1 = missingreport_s3(harvest, source="neon")
     load_release = neon_naburelease(harvest)

--- a/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_neotomadb.py
+++ b/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_neotomadb.py
@@ -227,7 +227,7 @@ def _create_container(
 
 def gleanerio(context, mode, source):
     ## ------------   Create
-
+    returnCode = 0
     get_dagster_logger().info(f"Gleanerio mode: {str(mode)}")
 
     if str(mode) == "gleaner":
@@ -277,7 +277,9 @@ def gleanerio(context, mode, source):
         Entrypoint = "nabu"
         # LOGFILE = 'log_nabu.txt'  # only used for local log file writing
     else:
-        return 1
+
+        returnCode = 1
+        return returnCode
 
     # from docker0dagster
     run_container_context = DockerContainerContext.create_for_run(
@@ -430,13 +432,23 @@ def gleanerio(context, mode, source):
         # container.start()
         # client.api.start(container=container.id)
         ## start is not working
-
-        for line in container.logs(stdout=True, stderr=True, stream=True, follow=True):
-            get_dagster_logger().debug(line)  # noqa: T201
+        try:
+            for line in container.logs(stdout=True, stderr=True, stream=True, follow=True):
+                get_dagster_logger().debug(line)  # noqa: T201
+        except docker.errors.APIError as ex:
+            get_dagster_logger().info(f"watch container logs failed Docker API ISSUE: ", ex)
+            returnCode = 1
+        except Exception as ex:
+            get_dagster_logger().info(f"watch container logs failed other issue: ", ex)
+            returnCode = 1
 
         # ## ------------  Wait expect 200
+        # we want to get the logs, no matter what, so do not exit, yet.
+        ## or should logs be moved into finally?
+        ### in which case they need to be methods that don't send back errors.
         exit_status = container.wait()["StatusCode"]
         get_dagster_logger().info(f"Container Wait Exit status:  {exit_status}")
+        returnCode = exit_status
 
 
 
@@ -444,7 +456,7 @@ def gleanerio(context, mode, source):
         ## ------------  Copy logs  expect 200
 
 
-        c = container.logs(stdout=True, stderr=True, stream=False, follow=True).decode('latin-1')
+        c = container.logs(stdout=True, stderr=True, stream=False, follow=False).decode('latin-1')
 
         # write to s3
 
@@ -489,65 +501,72 @@ def gleanerio(context, mode, source):
        #      i+=1
 
        # s3loader(r.read().decode('latin-1'), NAME)
-        s3loader(r.read(), f"{source}_{str(mode)}_runlogs")
+
     finally:
         if (not DEBUG) :
-            if (cid):
-                url = URL + 'containers/' + cid
-                req = request.Request(url, method="DELETE")
-                req.add_header('X-API-Key', APIKEY)
-                # req.add_header('content-type', 'application/json')
-                req.add_header('accept', 'application/json')
-                r = request.urlopen(req)
-                print(r.status)
+            # if (cid):
+            #     url = URL + 'containers/' + cid
+            #     req = request.Request(url, method="DELETE")
+            #     req.add_header('X-API-Key', APIKEY)
+            #     # req.add_header('content-type', 'application/json')
+            #     req.add_header('accept', 'application/json')
+            #     r = request.urlopen(req)
+            #     print(r.status)
+            #     get_dagster_logger().info(f"Container Remove: {str(r.status)}")
+            # else:
+            #     get_dagster_logger().info(f"Container Not created, so not removed.")
+            if (container):
+                container.remove(force=True)
                 get_dagster_logger().info(f"Container Remove: {str(r.status)}")
             else:
                 get_dagster_logger().info(f"Container Not created, so not removed.")
         else:
             get_dagster_logger().info(f"Container NOT Remove: DEBUG ENABLED")
 
-
-    return 0
+    if (returnCode != 0):
+        get_dagster_logger().info(f"Gleaner/Nabu container non-zero exit code. See logs in S3")
+        raise Exception("Gleaner/Nabu container non-zero exit code. See logs in S3")
+    return returnCode
 
 @op
-def neotomadb_gleaner(context):
+def neotomadb_gleaner(context)-> str:
     returned_value = gleanerio(context, ("gleaner"), "neotomadb")
     r = str('returned value:{}'.format(returned_value))
     get_dagster_logger().info(f"Gleaner notes are  {r} ")
     return r
 
 @op
-def neotomadb_nabu_prune(context, msg: str):
+def neotomadb_nabu_prune(context, msg: str)-> str:
     returned_value = gleanerio(context,("nabu"), "neotomadb")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def neotomadb_nabuprov(context, msg: str):
+def neotomadb_nabuprov(context, msg: str)-> str:
     returned_value = gleanerio(context,("prov"), "neotomadb")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def neotomadb_nabuorg(context, msg: str):
+def neotomadb_nabuorg(context, msg: str)-> str:
     returned_value = gleanerio(context,("orgs"), "neotomadb")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def neotomadb_naburelease(context, msg: str):
+def neotomadb_naburelease(context, msg: str) -> str:
     returned_value = gleanerio(context,("release"), "neotomadb")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 @op
-def neotomadb_uploadrelease(context, msg: str):
+def neotomadb_uploadrelease(context, msg: str) -> str:
     returned_value = postRelease("neotomadb")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 
 @op
-def neotomadb_missingreport_s3(context, msg: str):
+def neotomadb_missingreport_s3(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="neotomadb")
     source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -562,7 +581,7 @@ def neotomadb_missingreport_s3(context, msg: str):
     s3Minio.putReportFile(bucket, source_name, "missing_report_s3.json", report)
     return msg + r
 @op
-def neotomadb_missingreport_graph(context, msg: str):
+def neotomadb_missingreport_graph(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="neotomadb")
     source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -581,7 +600,7 @@ def neotomadb_missingreport_graph(context, msg: str):
 
     return msg + r
 @op
-def neotomadb_graph_reports(context, msg: str):
+def neotomadb_graph_reports(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="neotomadb")
     #source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -601,7 +620,7 @@ def neotomadb_graph_reports(context, msg: str):
     return msg + r
 
 @op
-def neotomadb_identifier_stats(context, msg: str):
+def neotomadb_identifier_stats(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="neotomadb")
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
     bucket = GLEANER_MINIO_BUCKET
@@ -614,7 +633,8 @@ def neotomadb_identifier_stats(context, msg: str):
     s3Minio.putReportFile(bucket, source_name, "identifier_stats.json", report)
     return msg + r
 
-def neotomadb_bucket_urls(context, msg: str):
+@op()
+def neotomadb_bucket_urls(context, msg: str) -> str:
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
     bucket = GLEANER_MINIO_BUCKET
     source_name = "neotomadb"
@@ -648,7 +668,7 @@ def harvest_neotomadb():
     report_ms3 = neotomadb_missingreport_s3(harvest)
     report_idstat = neotomadb_identifier_stats(report_ms3)
     # for some reason, this causes a msg parameter missing
-   # report_bucketurl = neotomadb_bucket_urls(report_idstat)
+    report_bucketurl = neotomadb_bucket_urls(report_idstat)
 
     #report1 = missingreport_s3(harvest, source="neotomadb")
     load_release = neotomadb_naburelease(harvest)

--- a/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_opencoredata.py
+++ b/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_opencoredata.py
@@ -227,7 +227,7 @@ def _create_container(
 
 def gleanerio(context, mode, source):
     ## ------------   Create
-
+    returnCode = 0
     get_dagster_logger().info(f"Gleanerio mode: {str(mode)}")
 
     if str(mode) == "gleaner":
@@ -277,7 +277,9 @@ def gleanerio(context, mode, source):
         Entrypoint = "nabu"
         # LOGFILE = 'log_nabu.txt'  # only used for local log file writing
     else:
-        return 1
+
+        returnCode = 1
+        return returnCode
 
     # from docker0dagster
     run_container_context = DockerContainerContext.create_for_run(
@@ -430,13 +432,23 @@ def gleanerio(context, mode, source):
         # container.start()
         # client.api.start(container=container.id)
         ## start is not working
-
-        for line in container.logs(stdout=True, stderr=True, stream=True, follow=True):
-            get_dagster_logger().debug(line)  # noqa: T201
+        try:
+            for line in container.logs(stdout=True, stderr=True, stream=True, follow=True):
+                get_dagster_logger().debug(line)  # noqa: T201
+        except docker.errors.APIError as ex:
+            get_dagster_logger().info(f"watch container logs failed Docker API ISSUE: ", ex)
+            returnCode = 1
+        except Exception as ex:
+            get_dagster_logger().info(f"watch container logs failed other issue: ", ex)
+            returnCode = 1
 
         # ## ------------  Wait expect 200
+        # we want to get the logs, no matter what, so do not exit, yet.
+        ## or should logs be moved into finally?
+        ### in which case they need to be methods that don't send back errors.
         exit_status = container.wait()["StatusCode"]
         get_dagster_logger().info(f"Container Wait Exit status:  {exit_status}")
+        returnCode = exit_status
 
 
 
@@ -444,7 +456,7 @@ def gleanerio(context, mode, source):
         ## ------------  Copy logs  expect 200
 
 
-        c = container.logs(stdout=True, stderr=True, stream=False, follow=True).decode('latin-1')
+        c = container.logs(stdout=True, stderr=True, stream=False, follow=False).decode('latin-1')
 
         # write to s3
 
@@ -489,65 +501,72 @@ def gleanerio(context, mode, source):
        #      i+=1
 
        # s3loader(r.read().decode('latin-1'), NAME)
-        s3loader(r.read(), f"{source}_{str(mode)}_runlogs")
+
     finally:
         if (not DEBUG) :
-            if (cid):
-                url = URL + 'containers/' + cid
-                req = request.Request(url, method="DELETE")
-                req.add_header('X-API-Key', APIKEY)
-                # req.add_header('content-type', 'application/json')
-                req.add_header('accept', 'application/json')
-                r = request.urlopen(req)
-                print(r.status)
+            # if (cid):
+            #     url = URL + 'containers/' + cid
+            #     req = request.Request(url, method="DELETE")
+            #     req.add_header('X-API-Key', APIKEY)
+            #     # req.add_header('content-type', 'application/json')
+            #     req.add_header('accept', 'application/json')
+            #     r = request.urlopen(req)
+            #     print(r.status)
+            #     get_dagster_logger().info(f"Container Remove: {str(r.status)}")
+            # else:
+            #     get_dagster_logger().info(f"Container Not created, so not removed.")
+            if (container):
+                container.remove(force=True)
                 get_dagster_logger().info(f"Container Remove: {str(r.status)}")
             else:
                 get_dagster_logger().info(f"Container Not created, so not removed.")
         else:
             get_dagster_logger().info(f"Container NOT Remove: DEBUG ENABLED")
 
-
-    return 0
+    if (returnCode != 0):
+        get_dagster_logger().info(f"Gleaner/Nabu container non-zero exit code. See logs in S3")
+        raise Exception("Gleaner/Nabu container non-zero exit code. See logs in S3")
+    return returnCode
 
 @op
-def opencoredata_gleaner(context):
+def opencoredata_gleaner(context)-> str:
     returned_value = gleanerio(context, ("gleaner"), "opencoredata")
     r = str('returned value:{}'.format(returned_value))
     get_dagster_logger().info(f"Gleaner notes are  {r} ")
     return r
 
 @op
-def opencoredata_nabu_prune(context, msg: str):
+def opencoredata_nabu_prune(context, msg: str)-> str:
     returned_value = gleanerio(context,("nabu"), "opencoredata")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def opencoredata_nabuprov(context, msg: str):
+def opencoredata_nabuprov(context, msg: str)-> str:
     returned_value = gleanerio(context,("prov"), "opencoredata")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def opencoredata_nabuorg(context, msg: str):
+def opencoredata_nabuorg(context, msg: str)-> str:
     returned_value = gleanerio(context,("orgs"), "opencoredata")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def opencoredata_naburelease(context, msg: str):
+def opencoredata_naburelease(context, msg: str) -> str:
     returned_value = gleanerio(context,("release"), "opencoredata")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 @op
-def opencoredata_uploadrelease(context, msg: str):
+def opencoredata_uploadrelease(context, msg: str) -> str:
     returned_value = postRelease("opencoredata")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 
 @op
-def opencoredata_missingreport_s3(context, msg: str):
+def opencoredata_missingreport_s3(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="opencoredata")
     source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -562,7 +581,7 @@ def opencoredata_missingreport_s3(context, msg: str):
     s3Minio.putReportFile(bucket, source_name, "missing_report_s3.json", report)
     return msg + r
 @op
-def opencoredata_missingreport_graph(context, msg: str):
+def opencoredata_missingreport_graph(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="opencoredata")
     source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -581,7 +600,7 @@ def opencoredata_missingreport_graph(context, msg: str):
 
     return msg + r
 @op
-def opencoredata_graph_reports(context, msg: str):
+def opencoredata_graph_reports(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="opencoredata")
     #source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -601,7 +620,7 @@ def opencoredata_graph_reports(context, msg: str):
     return msg + r
 
 @op
-def opencoredata_identifier_stats(context, msg: str):
+def opencoredata_identifier_stats(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="opencoredata")
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
     bucket = GLEANER_MINIO_BUCKET
@@ -614,7 +633,8 @@ def opencoredata_identifier_stats(context, msg: str):
     s3Minio.putReportFile(bucket, source_name, "identifier_stats.json", report)
     return msg + r
 
-def opencoredata_bucket_urls(context, msg: str):
+@op()
+def opencoredata_bucket_urls(context, msg: str) -> str:
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
     bucket = GLEANER_MINIO_BUCKET
     source_name = "opencoredata"
@@ -648,7 +668,7 @@ def harvest_opencoredata():
     report_ms3 = opencoredata_missingreport_s3(harvest)
     report_idstat = opencoredata_identifier_stats(report_ms3)
     # for some reason, this causes a msg parameter missing
-   # report_bucketurl = opencoredata_bucket_urls(report_idstat)
+    report_bucketurl = opencoredata_bucket_urls(report_idstat)
 
     #report1 = missingreport_s3(harvest, source="opencoredata")
     load_release = opencoredata_naburelease(harvest)

--- a/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_opentopography.py
+++ b/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_opentopography.py
@@ -227,7 +227,7 @@ def _create_container(
 
 def gleanerio(context, mode, source):
     ## ------------   Create
-
+    returnCode = 0
     get_dagster_logger().info(f"Gleanerio mode: {str(mode)}")
 
     if str(mode) == "gleaner":
@@ -277,7 +277,9 @@ def gleanerio(context, mode, source):
         Entrypoint = "nabu"
         # LOGFILE = 'log_nabu.txt'  # only used for local log file writing
     else:
-        return 1
+
+        returnCode = 1
+        return returnCode
 
     # from docker0dagster
     run_container_context = DockerContainerContext.create_for_run(
@@ -430,13 +432,23 @@ def gleanerio(context, mode, source):
         # container.start()
         # client.api.start(container=container.id)
         ## start is not working
-
-        for line in container.logs(stdout=True, stderr=True, stream=True, follow=True):
-            get_dagster_logger().debug(line)  # noqa: T201
+        try:
+            for line in container.logs(stdout=True, stderr=True, stream=True, follow=True):
+                get_dagster_logger().debug(line)  # noqa: T201
+        except docker.errors.APIError as ex:
+            get_dagster_logger().info(f"watch container logs failed Docker API ISSUE: ", ex)
+            returnCode = 1
+        except Exception as ex:
+            get_dagster_logger().info(f"watch container logs failed other issue: ", ex)
+            returnCode = 1
 
         # ## ------------  Wait expect 200
+        # we want to get the logs, no matter what, so do not exit, yet.
+        ## or should logs be moved into finally?
+        ### in which case they need to be methods that don't send back errors.
         exit_status = container.wait()["StatusCode"]
         get_dagster_logger().info(f"Container Wait Exit status:  {exit_status}")
+        returnCode = exit_status
 
 
 
@@ -444,7 +456,7 @@ def gleanerio(context, mode, source):
         ## ------------  Copy logs  expect 200
 
 
-        c = container.logs(stdout=True, stderr=True, stream=False, follow=True).decode('latin-1')
+        c = container.logs(stdout=True, stderr=True, stream=False, follow=False).decode('latin-1')
 
         # write to s3
 
@@ -489,65 +501,72 @@ def gleanerio(context, mode, source):
        #      i+=1
 
        # s3loader(r.read().decode('latin-1'), NAME)
-        s3loader(r.read(), f"{source}_{str(mode)}_runlogs")
+
     finally:
         if (not DEBUG) :
-            if (cid):
-                url = URL + 'containers/' + cid
-                req = request.Request(url, method="DELETE")
-                req.add_header('X-API-Key', APIKEY)
-                # req.add_header('content-type', 'application/json')
-                req.add_header('accept', 'application/json')
-                r = request.urlopen(req)
-                print(r.status)
+            # if (cid):
+            #     url = URL + 'containers/' + cid
+            #     req = request.Request(url, method="DELETE")
+            #     req.add_header('X-API-Key', APIKEY)
+            #     # req.add_header('content-type', 'application/json')
+            #     req.add_header('accept', 'application/json')
+            #     r = request.urlopen(req)
+            #     print(r.status)
+            #     get_dagster_logger().info(f"Container Remove: {str(r.status)}")
+            # else:
+            #     get_dagster_logger().info(f"Container Not created, so not removed.")
+            if (container):
+                container.remove(force=True)
                 get_dagster_logger().info(f"Container Remove: {str(r.status)}")
             else:
                 get_dagster_logger().info(f"Container Not created, so not removed.")
         else:
             get_dagster_logger().info(f"Container NOT Remove: DEBUG ENABLED")
 
-
-    return 0
+    if (returnCode != 0):
+        get_dagster_logger().info(f"Gleaner/Nabu container non-zero exit code. See logs in S3")
+        raise Exception("Gleaner/Nabu container non-zero exit code. See logs in S3")
+    return returnCode
 
 @op
-def opentopography_gleaner(context):
+def opentopography_gleaner(context)-> str:
     returned_value = gleanerio(context, ("gleaner"), "opentopography")
     r = str('returned value:{}'.format(returned_value))
     get_dagster_logger().info(f"Gleaner notes are  {r} ")
     return r
 
 @op
-def opentopography_nabu_prune(context, msg: str):
+def opentopography_nabu_prune(context, msg: str)-> str:
     returned_value = gleanerio(context,("nabu"), "opentopography")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def opentopography_nabuprov(context, msg: str):
+def opentopography_nabuprov(context, msg: str)-> str:
     returned_value = gleanerio(context,("prov"), "opentopography")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def opentopography_nabuorg(context, msg: str):
+def opentopography_nabuorg(context, msg: str)-> str:
     returned_value = gleanerio(context,("orgs"), "opentopography")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def opentopography_naburelease(context, msg: str):
+def opentopography_naburelease(context, msg: str) -> str:
     returned_value = gleanerio(context,("release"), "opentopography")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 @op
-def opentopography_uploadrelease(context, msg: str):
+def opentopography_uploadrelease(context, msg: str) -> str:
     returned_value = postRelease("opentopography")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 
 @op
-def opentopography_missingreport_s3(context, msg: str):
+def opentopography_missingreport_s3(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="opentopography")
     source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -562,7 +581,7 @@ def opentopography_missingreport_s3(context, msg: str):
     s3Minio.putReportFile(bucket, source_name, "missing_report_s3.json", report)
     return msg + r
 @op
-def opentopography_missingreport_graph(context, msg: str):
+def opentopography_missingreport_graph(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="opentopography")
     source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -581,7 +600,7 @@ def opentopography_missingreport_graph(context, msg: str):
 
     return msg + r
 @op
-def opentopography_graph_reports(context, msg: str):
+def opentopography_graph_reports(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="opentopography")
     #source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -601,7 +620,7 @@ def opentopography_graph_reports(context, msg: str):
     return msg + r
 
 @op
-def opentopography_identifier_stats(context, msg: str):
+def opentopography_identifier_stats(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="opentopography")
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
     bucket = GLEANER_MINIO_BUCKET
@@ -614,7 +633,8 @@ def opentopography_identifier_stats(context, msg: str):
     s3Minio.putReportFile(bucket, source_name, "identifier_stats.json", report)
     return msg + r
 
-def opentopography_bucket_urls(context, msg: str):
+@op()
+def opentopography_bucket_urls(context, msg: str) -> str:
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
     bucket = GLEANER_MINIO_BUCKET
     source_name = "opentopography"
@@ -648,7 +668,7 @@ def harvest_opentopography():
     report_ms3 = opentopography_missingreport_s3(harvest)
     report_idstat = opentopography_identifier_stats(report_ms3)
     # for some reason, this causes a msg parameter missing
-   # report_bucketurl = opentopography_bucket_urls(report_idstat)
+    report_bucketurl = opentopography_bucket_urls(report_idstat)
 
     #report1 = missingreport_s3(harvest, source="opentopography")
     load_release = opentopography_naburelease(harvest)

--- a/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_r2r.py
+++ b/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_r2r.py
@@ -227,7 +227,7 @@ def _create_container(
 
 def gleanerio(context, mode, source):
     ## ------------   Create
-
+    returnCode = 0
     get_dagster_logger().info(f"Gleanerio mode: {str(mode)}")
 
     if str(mode) == "gleaner":
@@ -277,7 +277,9 @@ def gleanerio(context, mode, source):
         Entrypoint = "nabu"
         # LOGFILE = 'log_nabu.txt'  # only used for local log file writing
     else:
-        return 1
+
+        returnCode = 1
+        return returnCode
 
     # from docker0dagster
     run_container_context = DockerContainerContext.create_for_run(
@@ -430,13 +432,23 @@ def gleanerio(context, mode, source):
         # container.start()
         # client.api.start(container=container.id)
         ## start is not working
-
-        for line in container.logs(stdout=True, stderr=True, stream=True, follow=True):
-            get_dagster_logger().debug(line)  # noqa: T201
+        try:
+            for line in container.logs(stdout=True, stderr=True, stream=True, follow=True):
+                get_dagster_logger().debug(line)  # noqa: T201
+        except docker.errors.APIError as ex:
+            get_dagster_logger().info(f"watch container logs failed Docker API ISSUE: ", ex)
+            returnCode = 1
+        except Exception as ex:
+            get_dagster_logger().info(f"watch container logs failed other issue: ", ex)
+            returnCode = 1
 
         # ## ------------  Wait expect 200
+        # we want to get the logs, no matter what, so do not exit, yet.
+        ## or should logs be moved into finally?
+        ### in which case they need to be methods that don't send back errors.
         exit_status = container.wait()["StatusCode"]
         get_dagster_logger().info(f"Container Wait Exit status:  {exit_status}")
+        returnCode = exit_status
 
 
 
@@ -444,7 +456,7 @@ def gleanerio(context, mode, source):
         ## ------------  Copy logs  expect 200
 
 
-        c = container.logs(stdout=True, stderr=True, stream=False, follow=True).decode('latin-1')
+        c = container.logs(stdout=True, stderr=True, stream=False, follow=False).decode('latin-1')
 
         # write to s3
 
@@ -489,65 +501,72 @@ def gleanerio(context, mode, source):
        #      i+=1
 
        # s3loader(r.read().decode('latin-1'), NAME)
-        s3loader(r.read(), f"{source}_{str(mode)}_runlogs")
+
     finally:
         if (not DEBUG) :
-            if (cid):
-                url = URL + 'containers/' + cid
-                req = request.Request(url, method="DELETE")
-                req.add_header('X-API-Key', APIKEY)
-                # req.add_header('content-type', 'application/json')
-                req.add_header('accept', 'application/json')
-                r = request.urlopen(req)
-                print(r.status)
+            # if (cid):
+            #     url = URL + 'containers/' + cid
+            #     req = request.Request(url, method="DELETE")
+            #     req.add_header('X-API-Key', APIKEY)
+            #     # req.add_header('content-type', 'application/json')
+            #     req.add_header('accept', 'application/json')
+            #     r = request.urlopen(req)
+            #     print(r.status)
+            #     get_dagster_logger().info(f"Container Remove: {str(r.status)}")
+            # else:
+            #     get_dagster_logger().info(f"Container Not created, so not removed.")
+            if (container):
+                container.remove(force=True)
                 get_dagster_logger().info(f"Container Remove: {str(r.status)}")
             else:
                 get_dagster_logger().info(f"Container Not created, so not removed.")
         else:
             get_dagster_logger().info(f"Container NOT Remove: DEBUG ENABLED")
 
-
-    return 0
+    if (returnCode != 0):
+        get_dagster_logger().info(f"Gleaner/Nabu container non-zero exit code. See logs in S3")
+        raise Exception("Gleaner/Nabu container non-zero exit code. See logs in S3")
+    return returnCode
 
 @op
-def r2r_gleaner(context):
+def r2r_gleaner(context)-> str:
     returned_value = gleanerio(context, ("gleaner"), "r2r")
     r = str('returned value:{}'.format(returned_value))
     get_dagster_logger().info(f"Gleaner notes are  {r} ")
     return r
 
 @op
-def r2r_nabu_prune(context, msg: str):
+def r2r_nabu_prune(context, msg: str)-> str:
     returned_value = gleanerio(context,("nabu"), "r2r")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def r2r_nabuprov(context, msg: str):
+def r2r_nabuprov(context, msg: str)-> str:
     returned_value = gleanerio(context,("prov"), "r2r")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def r2r_nabuorg(context, msg: str):
+def r2r_nabuorg(context, msg: str)-> str:
     returned_value = gleanerio(context,("orgs"), "r2r")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def r2r_naburelease(context, msg: str):
+def r2r_naburelease(context, msg: str) -> str:
     returned_value = gleanerio(context,("release"), "r2r")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 @op
-def r2r_uploadrelease(context, msg: str):
+def r2r_uploadrelease(context, msg: str) -> str:
     returned_value = postRelease("r2r")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 
 @op
-def r2r_missingreport_s3(context, msg: str):
+def r2r_missingreport_s3(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="r2r")
     source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -562,7 +581,7 @@ def r2r_missingreport_s3(context, msg: str):
     s3Minio.putReportFile(bucket, source_name, "missing_report_s3.json", report)
     return msg + r
 @op
-def r2r_missingreport_graph(context, msg: str):
+def r2r_missingreport_graph(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="r2r")
     source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -581,7 +600,7 @@ def r2r_missingreport_graph(context, msg: str):
 
     return msg + r
 @op
-def r2r_graph_reports(context, msg: str):
+def r2r_graph_reports(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="r2r")
     #source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -601,7 +620,7 @@ def r2r_graph_reports(context, msg: str):
     return msg + r
 
 @op
-def r2r_identifier_stats(context, msg: str):
+def r2r_identifier_stats(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="r2r")
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
     bucket = GLEANER_MINIO_BUCKET
@@ -614,7 +633,8 @@ def r2r_identifier_stats(context, msg: str):
     s3Minio.putReportFile(bucket, source_name, "identifier_stats.json", report)
     return msg + r
 
-def r2r_bucket_urls(context, msg: str):
+@op()
+def r2r_bucket_urls(context, msg: str) -> str:
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
     bucket = GLEANER_MINIO_BUCKET
     source_name = "r2r"
@@ -648,7 +668,7 @@ def harvest_r2r():
     report_ms3 = r2r_missingreport_s3(harvest)
     report_idstat = r2r_identifier_stats(report_ms3)
     # for some reason, this causes a msg parameter missing
-   # report_bucketurl = r2r_bucket_urls(report_idstat)
+    report_bucketurl = r2r_bucket_urls(report_idstat)
 
     #report1 = missingreport_s3(harvest, source="r2r")
     load_release = r2r_naburelease(harvest)

--- a/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_resourceregistry.py
+++ b/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_resourceregistry.py
@@ -227,7 +227,7 @@ def _create_container(
 
 def gleanerio(context, mode, source):
     ## ------------   Create
-
+    returnCode = 0
     get_dagster_logger().info(f"Gleanerio mode: {str(mode)}")
 
     if str(mode) == "gleaner":
@@ -277,7 +277,9 @@ def gleanerio(context, mode, source):
         Entrypoint = "nabu"
         # LOGFILE = 'log_nabu.txt'  # only used for local log file writing
     else:
-        return 1
+
+        returnCode = 1
+        return returnCode
 
     # from docker0dagster
     run_container_context = DockerContainerContext.create_for_run(
@@ -430,13 +432,23 @@ def gleanerio(context, mode, source):
         # container.start()
         # client.api.start(container=container.id)
         ## start is not working
-
-        for line in container.logs(stdout=True, stderr=True, stream=True, follow=True):
-            get_dagster_logger().debug(line)  # noqa: T201
+        try:
+            for line in container.logs(stdout=True, stderr=True, stream=True, follow=True):
+                get_dagster_logger().debug(line)  # noqa: T201
+        except docker.errors.APIError as ex:
+            get_dagster_logger().info(f"watch container logs failed Docker API ISSUE: ", ex)
+            returnCode = 1
+        except Exception as ex:
+            get_dagster_logger().info(f"watch container logs failed other issue: ", ex)
+            returnCode = 1
 
         # ## ------------  Wait expect 200
+        # we want to get the logs, no matter what, so do not exit, yet.
+        ## or should logs be moved into finally?
+        ### in which case they need to be methods that don't send back errors.
         exit_status = container.wait()["StatusCode"]
         get_dagster_logger().info(f"Container Wait Exit status:  {exit_status}")
+        returnCode = exit_status
 
 
 
@@ -444,7 +456,7 @@ def gleanerio(context, mode, source):
         ## ------------  Copy logs  expect 200
 
 
-        c = container.logs(stdout=True, stderr=True, stream=False, follow=True).decode('latin-1')
+        c = container.logs(stdout=True, stderr=True, stream=False, follow=False).decode('latin-1')
 
         # write to s3
 
@@ -489,65 +501,72 @@ def gleanerio(context, mode, source):
        #      i+=1
 
        # s3loader(r.read().decode('latin-1'), NAME)
-        s3loader(r.read(), f"{source}_{str(mode)}_runlogs")
+
     finally:
         if (not DEBUG) :
-            if (cid):
-                url = URL + 'containers/' + cid
-                req = request.Request(url, method="DELETE")
-                req.add_header('X-API-Key', APIKEY)
-                # req.add_header('content-type', 'application/json')
-                req.add_header('accept', 'application/json')
-                r = request.urlopen(req)
-                print(r.status)
+            # if (cid):
+            #     url = URL + 'containers/' + cid
+            #     req = request.Request(url, method="DELETE")
+            #     req.add_header('X-API-Key', APIKEY)
+            #     # req.add_header('content-type', 'application/json')
+            #     req.add_header('accept', 'application/json')
+            #     r = request.urlopen(req)
+            #     print(r.status)
+            #     get_dagster_logger().info(f"Container Remove: {str(r.status)}")
+            # else:
+            #     get_dagster_logger().info(f"Container Not created, so not removed.")
+            if (container):
+                container.remove(force=True)
                 get_dagster_logger().info(f"Container Remove: {str(r.status)}")
             else:
                 get_dagster_logger().info(f"Container Not created, so not removed.")
         else:
             get_dagster_logger().info(f"Container NOT Remove: DEBUG ENABLED")
 
-
-    return 0
+    if (returnCode != 0):
+        get_dagster_logger().info(f"Gleaner/Nabu container non-zero exit code. See logs in S3")
+        raise Exception("Gleaner/Nabu container non-zero exit code. See logs in S3")
+    return returnCode
 
 @op
-def resourceregistry_gleaner(context):
+def resourceregistry_gleaner(context)-> str:
     returned_value = gleanerio(context, ("gleaner"), "resourceregistry")
     r = str('returned value:{}'.format(returned_value))
     get_dagster_logger().info(f"Gleaner notes are  {r} ")
     return r
 
 @op
-def resourceregistry_nabu_prune(context, msg: str):
+def resourceregistry_nabu_prune(context, msg: str)-> str:
     returned_value = gleanerio(context,("nabu"), "resourceregistry")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def resourceregistry_nabuprov(context, msg: str):
+def resourceregistry_nabuprov(context, msg: str)-> str:
     returned_value = gleanerio(context,("prov"), "resourceregistry")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def resourceregistry_nabuorg(context, msg: str):
+def resourceregistry_nabuorg(context, msg: str)-> str:
     returned_value = gleanerio(context,("orgs"), "resourceregistry")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def resourceregistry_naburelease(context, msg: str):
+def resourceregistry_naburelease(context, msg: str) -> str:
     returned_value = gleanerio(context,("release"), "resourceregistry")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 @op
-def resourceregistry_uploadrelease(context, msg: str):
+def resourceregistry_uploadrelease(context, msg: str) -> str:
     returned_value = postRelease("resourceregistry")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 
 @op
-def resourceregistry_missingreport_s3(context, msg: str):
+def resourceregistry_missingreport_s3(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="resourceregistry")
     source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -562,7 +581,7 @@ def resourceregistry_missingreport_s3(context, msg: str):
     s3Minio.putReportFile(bucket, source_name, "missing_report_s3.json", report)
     return msg + r
 @op
-def resourceregistry_missingreport_graph(context, msg: str):
+def resourceregistry_missingreport_graph(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="resourceregistry")
     source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -581,7 +600,7 @@ def resourceregistry_missingreport_graph(context, msg: str):
 
     return msg + r
 @op
-def resourceregistry_graph_reports(context, msg: str):
+def resourceregistry_graph_reports(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="resourceregistry")
     #source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -601,7 +620,7 @@ def resourceregistry_graph_reports(context, msg: str):
     return msg + r
 
 @op
-def resourceregistry_identifier_stats(context, msg: str):
+def resourceregistry_identifier_stats(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="resourceregistry")
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
     bucket = GLEANER_MINIO_BUCKET
@@ -614,7 +633,8 @@ def resourceregistry_identifier_stats(context, msg: str):
     s3Minio.putReportFile(bucket, source_name, "identifier_stats.json", report)
     return msg + r
 
-def resourceregistry_bucket_urls(context, msg: str):
+@op()
+def resourceregistry_bucket_urls(context, msg: str) -> str:
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
     bucket = GLEANER_MINIO_BUCKET
     source_name = "resourceregistry"
@@ -648,7 +668,7 @@ def harvest_resourceregistry():
     report_ms3 = resourceregistry_missingreport_s3(harvest)
     report_idstat = resourceregistry_identifier_stats(report_ms3)
     # for some reason, this causes a msg parameter missing
-   # report_bucketurl = resourceregistry_bucket_urls(report_idstat)
+    report_bucketurl = resourceregistry_bucket_urls(report_idstat)
 
     #report1 = missingreport_s3(harvest, source="resourceregistry")
     load_release = resourceregistry_naburelease(harvest)

--- a/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_ssdbiodp.py
+++ b/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_ssdbiodp.py
@@ -227,7 +227,7 @@ def _create_container(
 
 def gleanerio(context, mode, source):
     ## ------------   Create
-
+    returnCode = 0
     get_dagster_logger().info(f"Gleanerio mode: {str(mode)}")
 
     if str(mode) == "gleaner":
@@ -277,7 +277,9 @@ def gleanerio(context, mode, source):
         Entrypoint = "nabu"
         # LOGFILE = 'log_nabu.txt'  # only used for local log file writing
     else:
-        return 1
+
+        returnCode = 1
+        return returnCode
 
     # from docker0dagster
     run_container_context = DockerContainerContext.create_for_run(
@@ -430,13 +432,23 @@ def gleanerio(context, mode, source):
         # container.start()
         # client.api.start(container=container.id)
         ## start is not working
-
-        for line in container.logs(stdout=True, stderr=True, stream=True, follow=True):
-            get_dagster_logger().debug(line)  # noqa: T201
+        try:
+            for line in container.logs(stdout=True, stderr=True, stream=True, follow=True):
+                get_dagster_logger().debug(line)  # noqa: T201
+        except docker.errors.APIError as ex:
+            get_dagster_logger().info(f"watch container logs failed Docker API ISSUE: ", ex)
+            returnCode = 1
+        except Exception as ex:
+            get_dagster_logger().info(f"watch container logs failed other issue: ", ex)
+            returnCode = 1
 
         # ## ------------  Wait expect 200
+        # we want to get the logs, no matter what, so do not exit, yet.
+        ## or should logs be moved into finally?
+        ### in which case they need to be methods that don't send back errors.
         exit_status = container.wait()["StatusCode"]
         get_dagster_logger().info(f"Container Wait Exit status:  {exit_status}")
+        returnCode = exit_status
 
 
 
@@ -444,7 +456,7 @@ def gleanerio(context, mode, source):
         ## ------------  Copy logs  expect 200
 
 
-        c = container.logs(stdout=True, stderr=True, stream=False, follow=True).decode('latin-1')
+        c = container.logs(stdout=True, stderr=True, stream=False, follow=False).decode('latin-1')
 
         # write to s3
 
@@ -489,65 +501,72 @@ def gleanerio(context, mode, source):
        #      i+=1
 
        # s3loader(r.read().decode('latin-1'), NAME)
-        s3loader(r.read(), f"{source}_{str(mode)}_runlogs")
+
     finally:
         if (not DEBUG) :
-            if (cid):
-                url = URL + 'containers/' + cid
-                req = request.Request(url, method="DELETE")
-                req.add_header('X-API-Key', APIKEY)
-                # req.add_header('content-type', 'application/json')
-                req.add_header('accept', 'application/json')
-                r = request.urlopen(req)
-                print(r.status)
+            # if (cid):
+            #     url = URL + 'containers/' + cid
+            #     req = request.Request(url, method="DELETE")
+            #     req.add_header('X-API-Key', APIKEY)
+            #     # req.add_header('content-type', 'application/json')
+            #     req.add_header('accept', 'application/json')
+            #     r = request.urlopen(req)
+            #     print(r.status)
+            #     get_dagster_logger().info(f"Container Remove: {str(r.status)}")
+            # else:
+            #     get_dagster_logger().info(f"Container Not created, so not removed.")
+            if (container):
+                container.remove(force=True)
                 get_dagster_logger().info(f"Container Remove: {str(r.status)}")
             else:
                 get_dagster_logger().info(f"Container Not created, so not removed.")
         else:
             get_dagster_logger().info(f"Container NOT Remove: DEBUG ENABLED")
 
-
-    return 0
+    if (returnCode != 0):
+        get_dagster_logger().info(f"Gleaner/Nabu container non-zero exit code. See logs in S3")
+        raise Exception("Gleaner/Nabu container non-zero exit code. See logs in S3")
+    return returnCode
 
 @op
-def ssdbiodp_gleaner(context):
+def ssdbiodp_gleaner(context)-> str:
     returned_value = gleanerio(context, ("gleaner"), "ssdbiodp")
     r = str('returned value:{}'.format(returned_value))
     get_dagster_logger().info(f"Gleaner notes are  {r} ")
     return r
 
 @op
-def ssdbiodp_nabu_prune(context, msg: str):
+def ssdbiodp_nabu_prune(context, msg: str)-> str:
     returned_value = gleanerio(context,("nabu"), "ssdbiodp")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def ssdbiodp_nabuprov(context, msg: str):
+def ssdbiodp_nabuprov(context, msg: str)-> str:
     returned_value = gleanerio(context,("prov"), "ssdbiodp")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def ssdbiodp_nabuorg(context, msg: str):
+def ssdbiodp_nabuorg(context, msg: str)-> str:
     returned_value = gleanerio(context,("orgs"), "ssdbiodp")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def ssdbiodp_naburelease(context, msg: str):
+def ssdbiodp_naburelease(context, msg: str) -> str:
     returned_value = gleanerio(context,("release"), "ssdbiodp")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 @op
-def ssdbiodp_uploadrelease(context, msg: str):
+def ssdbiodp_uploadrelease(context, msg: str) -> str:
     returned_value = postRelease("ssdbiodp")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 
 @op
-def ssdbiodp_missingreport_s3(context, msg: str):
+def ssdbiodp_missingreport_s3(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="ssdbiodp")
     source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -562,7 +581,7 @@ def ssdbiodp_missingreport_s3(context, msg: str):
     s3Minio.putReportFile(bucket, source_name, "missing_report_s3.json", report)
     return msg + r
 @op
-def ssdbiodp_missingreport_graph(context, msg: str):
+def ssdbiodp_missingreport_graph(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="ssdbiodp")
     source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -581,7 +600,7 @@ def ssdbiodp_missingreport_graph(context, msg: str):
 
     return msg + r
 @op
-def ssdbiodp_graph_reports(context, msg: str):
+def ssdbiodp_graph_reports(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="ssdbiodp")
     #source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -601,7 +620,7 @@ def ssdbiodp_graph_reports(context, msg: str):
     return msg + r
 
 @op
-def ssdbiodp_identifier_stats(context, msg: str):
+def ssdbiodp_identifier_stats(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="ssdbiodp")
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
     bucket = GLEANER_MINIO_BUCKET
@@ -614,7 +633,8 @@ def ssdbiodp_identifier_stats(context, msg: str):
     s3Minio.putReportFile(bucket, source_name, "identifier_stats.json", report)
     return msg + r
 
-def ssdbiodp_bucket_urls(context, msg: str):
+@op()
+def ssdbiodp_bucket_urls(context, msg: str) -> str:
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
     bucket = GLEANER_MINIO_BUCKET
     source_name = "ssdbiodp"
@@ -648,7 +668,7 @@ def harvest_ssdbiodp():
     report_ms3 = ssdbiodp_missingreport_s3(harvest)
     report_idstat = ssdbiodp_identifier_stats(report_ms3)
     # for some reason, this causes a msg parameter missing
-   # report_bucketurl = ssdbiodp_bucket_urls(report_idstat)
+    report_bucketurl = ssdbiodp_bucket_urls(report_idstat)
 
     #report1 = missingreport_s3(harvest, source="ssdbiodp")
     load_release = ssdbiodp_naburelease(harvest)

--- a/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_ucar.py
+++ b/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_ucar.py
@@ -227,7 +227,7 @@ def _create_container(
 
 def gleanerio(context, mode, source):
     ## ------------   Create
-
+    returnCode = 0
     get_dagster_logger().info(f"Gleanerio mode: {str(mode)}")
 
     if str(mode) == "gleaner":
@@ -277,7 +277,9 @@ def gleanerio(context, mode, source):
         Entrypoint = "nabu"
         # LOGFILE = 'log_nabu.txt'  # only used for local log file writing
     else:
-        return 1
+
+        returnCode = 1
+        return returnCode
 
     # from docker0dagster
     run_container_context = DockerContainerContext.create_for_run(
@@ -430,13 +432,23 @@ def gleanerio(context, mode, source):
         # container.start()
         # client.api.start(container=container.id)
         ## start is not working
-
-        for line in container.logs(stdout=True, stderr=True, stream=True, follow=True):
-            get_dagster_logger().debug(line)  # noqa: T201
+        try:
+            for line in container.logs(stdout=True, stderr=True, stream=True, follow=True):
+                get_dagster_logger().debug(line)  # noqa: T201
+        except docker.errors.APIError as ex:
+            get_dagster_logger().info(f"watch container logs failed Docker API ISSUE: ", ex)
+            returnCode = 1
+        except Exception as ex:
+            get_dagster_logger().info(f"watch container logs failed other issue: ", ex)
+            returnCode = 1
 
         # ## ------------  Wait expect 200
+        # we want to get the logs, no matter what, so do not exit, yet.
+        ## or should logs be moved into finally?
+        ### in which case they need to be methods that don't send back errors.
         exit_status = container.wait()["StatusCode"]
         get_dagster_logger().info(f"Container Wait Exit status:  {exit_status}")
+        returnCode = exit_status
 
 
 
@@ -444,7 +456,7 @@ def gleanerio(context, mode, source):
         ## ------------  Copy logs  expect 200
 
 
-        c = container.logs(stdout=True, stderr=True, stream=False, follow=True).decode('latin-1')
+        c = container.logs(stdout=True, stderr=True, stream=False, follow=False).decode('latin-1')
 
         # write to s3
 
@@ -489,65 +501,72 @@ def gleanerio(context, mode, source):
        #      i+=1
 
        # s3loader(r.read().decode('latin-1'), NAME)
-        s3loader(r.read(), f"{source}_{str(mode)}_runlogs")
+
     finally:
         if (not DEBUG) :
-            if (cid):
-                url = URL + 'containers/' + cid
-                req = request.Request(url, method="DELETE")
-                req.add_header('X-API-Key', APIKEY)
-                # req.add_header('content-type', 'application/json')
-                req.add_header('accept', 'application/json')
-                r = request.urlopen(req)
-                print(r.status)
+            # if (cid):
+            #     url = URL + 'containers/' + cid
+            #     req = request.Request(url, method="DELETE")
+            #     req.add_header('X-API-Key', APIKEY)
+            #     # req.add_header('content-type', 'application/json')
+            #     req.add_header('accept', 'application/json')
+            #     r = request.urlopen(req)
+            #     print(r.status)
+            #     get_dagster_logger().info(f"Container Remove: {str(r.status)}")
+            # else:
+            #     get_dagster_logger().info(f"Container Not created, so not removed.")
+            if (container):
+                container.remove(force=True)
                 get_dagster_logger().info(f"Container Remove: {str(r.status)}")
             else:
                 get_dagster_logger().info(f"Container Not created, so not removed.")
         else:
             get_dagster_logger().info(f"Container NOT Remove: DEBUG ENABLED")
 
-
-    return 0
+    if (returnCode != 0):
+        get_dagster_logger().info(f"Gleaner/Nabu container non-zero exit code. See logs in S3")
+        raise Exception("Gleaner/Nabu container non-zero exit code. See logs in S3")
+    return returnCode
 
 @op
-def ucar_gleaner(context):
+def ucar_gleaner(context)-> str:
     returned_value = gleanerio(context, ("gleaner"), "ucar")
     r = str('returned value:{}'.format(returned_value))
     get_dagster_logger().info(f"Gleaner notes are  {r} ")
     return r
 
 @op
-def ucar_nabu_prune(context, msg: str):
+def ucar_nabu_prune(context, msg: str)-> str:
     returned_value = gleanerio(context,("nabu"), "ucar")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def ucar_nabuprov(context, msg: str):
+def ucar_nabuprov(context, msg: str)-> str:
     returned_value = gleanerio(context,("prov"), "ucar")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def ucar_nabuorg(context, msg: str):
+def ucar_nabuorg(context, msg: str)-> str:
     returned_value = gleanerio(context,("orgs"), "ucar")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def ucar_naburelease(context, msg: str):
+def ucar_naburelease(context, msg: str) -> str:
     returned_value = gleanerio(context,("release"), "ucar")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 @op
-def ucar_uploadrelease(context, msg: str):
+def ucar_uploadrelease(context, msg: str) -> str:
     returned_value = postRelease("ucar")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 
 @op
-def ucar_missingreport_s3(context, msg: str):
+def ucar_missingreport_s3(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="ucar")
     source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -562,7 +581,7 @@ def ucar_missingreport_s3(context, msg: str):
     s3Minio.putReportFile(bucket, source_name, "missing_report_s3.json", report)
     return msg + r
 @op
-def ucar_missingreport_graph(context, msg: str):
+def ucar_missingreport_graph(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="ucar")
     source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -581,7 +600,7 @@ def ucar_missingreport_graph(context, msg: str):
 
     return msg + r
 @op
-def ucar_graph_reports(context, msg: str):
+def ucar_graph_reports(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="ucar")
     #source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -601,7 +620,7 @@ def ucar_graph_reports(context, msg: str):
     return msg + r
 
 @op
-def ucar_identifier_stats(context, msg: str):
+def ucar_identifier_stats(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="ucar")
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
     bucket = GLEANER_MINIO_BUCKET
@@ -614,7 +633,8 @@ def ucar_identifier_stats(context, msg: str):
     s3Minio.putReportFile(bucket, source_name, "identifier_stats.json", report)
     return msg + r
 
-def ucar_bucket_urls(context, msg: str):
+@op()
+def ucar_bucket_urls(context, msg: str) -> str:
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
     bucket = GLEANER_MINIO_BUCKET
     source_name = "ucar"
@@ -648,7 +668,7 @@ def harvest_ucar():
     report_ms3 = ucar_missingreport_s3(harvest)
     report_idstat = ucar_identifier_stats(report_ms3)
     # for some reason, this causes a msg parameter missing
-   # report_bucketurl = ucar_bucket_urls(report_idstat)
+    report_bucketurl = ucar_bucket_urls(report_idstat)
 
     #report1 = missingreport_s3(harvest, source="ucar")
     load_release = ucar_naburelease(harvest)

--- a/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_unavco.py
+++ b/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_unavco.py
@@ -227,7 +227,7 @@ def _create_container(
 
 def gleanerio(context, mode, source):
     ## ------------   Create
-
+    returnCode = 0
     get_dagster_logger().info(f"Gleanerio mode: {str(mode)}")
 
     if str(mode) == "gleaner":
@@ -277,7 +277,9 @@ def gleanerio(context, mode, source):
         Entrypoint = "nabu"
         # LOGFILE = 'log_nabu.txt'  # only used for local log file writing
     else:
-        return 1
+
+        returnCode = 1
+        return returnCode
 
     # from docker0dagster
     run_container_context = DockerContainerContext.create_for_run(
@@ -430,13 +432,23 @@ def gleanerio(context, mode, source):
         # container.start()
         # client.api.start(container=container.id)
         ## start is not working
-
-        for line in container.logs(stdout=True, stderr=True, stream=True, follow=True):
-            get_dagster_logger().debug(line)  # noqa: T201
+        try:
+            for line in container.logs(stdout=True, stderr=True, stream=True, follow=True):
+                get_dagster_logger().debug(line)  # noqa: T201
+        except docker.errors.APIError as ex:
+            get_dagster_logger().info(f"watch container logs failed Docker API ISSUE: ", ex)
+            returnCode = 1
+        except Exception as ex:
+            get_dagster_logger().info(f"watch container logs failed other issue: ", ex)
+            returnCode = 1
 
         # ## ------------  Wait expect 200
+        # we want to get the logs, no matter what, so do not exit, yet.
+        ## or should logs be moved into finally?
+        ### in which case they need to be methods that don't send back errors.
         exit_status = container.wait()["StatusCode"]
         get_dagster_logger().info(f"Container Wait Exit status:  {exit_status}")
+        returnCode = exit_status
 
 
 
@@ -444,7 +456,7 @@ def gleanerio(context, mode, source):
         ## ------------  Copy logs  expect 200
 
 
-        c = container.logs(stdout=True, stderr=True, stream=False, follow=True).decode('latin-1')
+        c = container.logs(stdout=True, stderr=True, stream=False, follow=False).decode('latin-1')
 
         # write to s3
 
@@ -489,65 +501,72 @@ def gleanerio(context, mode, source):
        #      i+=1
 
        # s3loader(r.read().decode('latin-1'), NAME)
-        s3loader(r.read(), f"{source}_{str(mode)}_runlogs")
+
     finally:
         if (not DEBUG) :
-            if (cid):
-                url = URL + 'containers/' + cid
-                req = request.Request(url, method="DELETE")
-                req.add_header('X-API-Key', APIKEY)
-                # req.add_header('content-type', 'application/json')
-                req.add_header('accept', 'application/json')
-                r = request.urlopen(req)
-                print(r.status)
+            # if (cid):
+            #     url = URL + 'containers/' + cid
+            #     req = request.Request(url, method="DELETE")
+            #     req.add_header('X-API-Key', APIKEY)
+            #     # req.add_header('content-type', 'application/json')
+            #     req.add_header('accept', 'application/json')
+            #     r = request.urlopen(req)
+            #     print(r.status)
+            #     get_dagster_logger().info(f"Container Remove: {str(r.status)}")
+            # else:
+            #     get_dagster_logger().info(f"Container Not created, so not removed.")
+            if (container):
+                container.remove(force=True)
                 get_dagster_logger().info(f"Container Remove: {str(r.status)}")
             else:
                 get_dagster_logger().info(f"Container Not created, so not removed.")
         else:
             get_dagster_logger().info(f"Container NOT Remove: DEBUG ENABLED")
 
-
-    return 0
+    if (returnCode != 0):
+        get_dagster_logger().info(f"Gleaner/Nabu container non-zero exit code. See logs in S3")
+        raise Exception("Gleaner/Nabu container non-zero exit code. See logs in S3")
+    return returnCode
 
 @op
-def unavco_gleaner(context):
+def unavco_gleaner(context)-> str:
     returned_value = gleanerio(context, ("gleaner"), "unavco")
     r = str('returned value:{}'.format(returned_value))
     get_dagster_logger().info(f"Gleaner notes are  {r} ")
     return r
 
 @op
-def unavco_nabu_prune(context, msg: str):
+def unavco_nabu_prune(context, msg: str)-> str:
     returned_value = gleanerio(context,("nabu"), "unavco")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def unavco_nabuprov(context, msg: str):
+def unavco_nabuprov(context, msg: str)-> str:
     returned_value = gleanerio(context,("prov"), "unavco")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def unavco_nabuorg(context, msg: str):
+def unavco_nabuorg(context, msg: str)-> str:
     returned_value = gleanerio(context,("orgs"), "unavco")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def unavco_naburelease(context, msg: str):
+def unavco_naburelease(context, msg: str) -> str:
     returned_value = gleanerio(context,("release"), "unavco")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 @op
-def unavco_uploadrelease(context, msg: str):
+def unavco_uploadrelease(context, msg: str) -> str:
     returned_value = postRelease("unavco")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 
 @op
-def unavco_missingreport_s3(context, msg: str):
+def unavco_missingreport_s3(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="unavco")
     source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -562,7 +581,7 @@ def unavco_missingreport_s3(context, msg: str):
     s3Minio.putReportFile(bucket, source_name, "missing_report_s3.json", report)
     return msg + r
 @op
-def unavco_missingreport_graph(context, msg: str):
+def unavco_missingreport_graph(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="unavco")
     source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -581,7 +600,7 @@ def unavco_missingreport_graph(context, msg: str):
 
     return msg + r
 @op
-def unavco_graph_reports(context, msg: str):
+def unavco_graph_reports(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="unavco")
     #source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -601,7 +620,7 @@ def unavco_graph_reports(context, msg: str):
     return msg + r
 
 @op
-def unavco_identifier_stats(context, msg: str):
+def unavco_identifier_stats(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="unavco")
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
     bucket = GLEANER_MINIO_BUCKET
@@ -614,7 +633,8 @@ def unavco_identifier_stats(context, msg: str):
     s3Minio.putReportFile(bucket, source_name, "identifier_stats.json", report)
     return msg + r
 
-def unavco_bucket_urls(context, msg: str):
+@op()
+def unavco_bucket_urls(context, msg: str) -> str:
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
     bucket = GLEANER_MINIO_BUCKET
     source_name = "unavco"
@@ -648,7 +668,7 @@ def harvest_unavco():
     report_ms3 = unavco_missingreport_s3(harvest)
     report_idstat = unavco_identifier_stats(report_ms3)
     # for some reason, this causes a msg parameter missing
-   # report_bucketurl = unavco_bucket_urls(report_idstat)
+    report_bucketurl = unavco_bucket_urls(report_idstat)
 
     #report1 = missingreport_s3(harvest, source="unavco")
     load_release = unavco_naburelease(harvest)

--- a/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_unidata.py
+++ b/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_unidata.py
@@ -227,7 +227,7 @@ def _create_container(
 
 def gleanerio(context, mode, source):
     ## ------------   Create
-
+    returnCode = 0
     get_dagster_logger().info(f"Gleanerio mode: {str(mode)}")
 
     if str(mode) == "gleaner":
@@ -277,7 +277,9 @@ def gleanerio(context, mode, source):
         Entrypoint = "nabu"
         # LOGFILE = 'log_nabu.txt'  # only used for local log file writing
     else:
-        return 1
+
+        returnCode = 1
+        return returnCode
 
     # from docker0dagster
     run_container_context = DockerContainerContext.create_for_run(
@@ -430,13 +432,23 @@ def gleanerio(context, mode, source):
         # container.start()
         # client.api.start(container=container.id)
         ## start is not working
-
-        for line in container.logs(stdout=True, stderr=True, stream=True, follow=True):
-            get_dagster_logger().debug(line)  # noqa: T201
+        try:
+            for line in container.logs(stdout=True, stderr=True, stream=True, follow=True):
+                get_dagster_logger().debug(line)  # noqa: T201
+        except docker.errors.APIError as ex:
+            get_dagster_logger().info(f"watch container logs failed Docker API ISSUE: ", ex)
+            returnCode = 1
+        except Exception as ex:
+            get_dagster_logger().info(f"watch container logs failed other issue: ", ex)
+            returnCode = 1
 
         # ## ------------  Wait expect 200
+        # we want to get the logs, no matter what, so do not exit, yet.
+        ## or should logs be moved into finally?
+        ### in which case they need to be methods that don't send back errors.
         exit_status = container.wait()["StatusCode"]
         get_dagster_logger().info(f"Container Wait Exit status:  {exit_status}")
+        returnCode = exit_status
 
 
 
@@ -444,7 +456,7 @@ def gleanerio(context, mode, source):
         ## ------------  Copy logs  expect 200
 
 
-        c = container.logs(stdout=True, stderr=True, stream=False, follow=True).decode('latin-1')
+        c = container.logs(stdout=True, stderr=True, stream=False, follow=False).decode('latin-1')
 
         # write to s3
 
@@ -489,65 +501,72 @@ def gleanerio(context, mode, source):
        #      i+=1
 
        # s3loader(r.read().decode('latin-1'), NAME)
-        s3loader(r.read(), f"{source}_{str(mode)}_runlogs")
+
     finally:
         if (not DEBUG) :
-            if (cid):
-                url = URL + 'containers/' + cid
-                req = request.Request(url, method="DELETE")
-                req.add_header('X-API-Key', APIKEY)
-                # req.add_header('content-type', 'application/json')
-                req.add_header('accept', 'application/json')
-                r = request.urlopen(req)
-                print(r.status)
+            # if (cid):
+            #     url = URL + 'containers/' + cid
+            #     req = request.Request(url, method="DELETE")
+            #     req.add_header('X-API-Key', APIKEY)
+            #     # req.add_header('content-type', 'application/json')
+            #     req.add_header('accept', 'application/json')
+            #     r = request.urlopen(req)
+            #     print(r.status)
+            #     get_dagster_logger().info(f"Container Remove: {str(r.status)}")
+            # else:
+            #     get_dagster_logger().info(f"Container Not created, so not removed.")
+            if (container):
+                container.remove(force=True)
                 get_dagster_logger().info(f"Container Remove: {str(r.status)}")
             else:
                 get_dagster_logger().info(f"Container Not created, so not removed.")
         else:
             get_dagster_logger().info(f"Container NOT Remove: DEBUG ENABLED")
 
-
-    return 0
+    if (returnCode != 0):
+        get_dagster_logger().info(f"Gleaner/Nabu container non-zero exit code. See logs in S3")
+        raise Exception("Gleaner/Nabu container non-zero exit code. See logs in S3")
+    return returnCode
 
 @op
-def unidata_gleaner(context):
+def unidata_gleaner(context)-> str:
     returned_value = gleanerio(context, ("gleaner"), "unidata")
     r = str('returned value:{}'.format(returned_value))
     get_dagster_logger().info(f"Gleaner notes are  {r} ")
     return r
 
 @op
-def unidata_nabu_prune(context, msg: str):
+def unidata_nabu_prune(context, msg: str)-> str:
     returned_value = gleanerio(context,("nabu"), "unidata")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def unidata_nabuprov(context, msg: str):
+def unidata_nabuprov(context, msg: str)-> str:
     returned_value = gleanerio(context,("prov"), "unidata")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def unidata_nabuorg(context, msg: str):
+def unidata_nabuorg(context, msg: str)-> str:
     returned_value = gleanerio(context,("orgs"), "unidata")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def unidata_naburelease(context, msg: str):
+def unidata_naburelease(context, msg: str) -> str:
     returned_value = gleanerio(context,("release"), "unidata")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 @op
-def unidata_uploadrelease(context, msg: str):
+def unidata_uploadrelease(context, msg: str) -> str:
     returned_value = postRelease("unidata")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 
 @op
-def unidata_missingreport_s3(context, msg: str):
+def unidata_missingreport_s3(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="unidata")
     source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -562,7 +581,7 @@ def unidata_missingreport_s3(context, msg: str):
     s3Minio.putReportFile(bucket, source_name, "missing_report_s3.json", report)
     return msg + r
 @op
-def unidata_missingreport_graph(context, msg: str):
+def unidata_missingreport_graph(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="unidata")
     source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -581,7 +600,7 @@ def unidata_missingreport_graph(context, msg: str):
 
     return msg + r
 @op
-def unidata_graph_reports(context, msg: str):
+def unidata_graph_reports(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="unidata")
     #source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -601,7 +620,7 @@ def unidata_graph_reports(context, msg: str):
     return msg + r
 
 @op
-def unidata_identifier_stats(context, msg: str):
+def unidata_identifier_stats(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="unidata")
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
     bucket = GLEANER_MINIO_BUCKET
@@ -614,7 +633,8 @@ def unidata_identifier_stats(context, msg: str):
     s3Minio.putReportFile(bucket, source_name, "identifier_stats.json", report)
     return msg + r
 
-def unidata_bucket_urls(context, msg: str):
+@op()
+def unidata_bucket_urls(context, msg: str) -> str:
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
     bucket = GLEANER_MINIO_BUCKET
     source_name = "unidata"
@@ -648,7 +668,7 @@ def harvest_unidata():
     report_ms3 = unidata_missingreport_s3(harvest)
     report_idstat = unidata_identifier_stats(report_ms3)
     # for some reason, this causes a msg parameter missing
-   # report_bucketurl = unidata_bucket_urls(report_idstat)
+    report_bucketurl = unidata_bucket_urls(report_idstat)
 
     #report1 = missingreport_s3(harvest, source="unidata")
     load_release = unidata_naburelease(harvest)

--- a/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_usapdc.py
+++ b/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_usapdc.py
@@ -227,7 +227,7 @@ def _create_container(
 
 def gleanerio(context, mode, source):
     ## ------------   Create
-
+    returnCode = 0
     get_dagster_logger().info(f"Gleanerio mode: {str(mode)}")
 
     if str(mode) == "gleaner":
@@ -277,7 +277,9 @@ def gleanerio(context, mode, source):
         Entrypoint = "nabu"
         # LOGFILE = 'log_nabu.txt'  # only used for local log file writing
     else:
-        return 1
+
+        returnCode = 1
+        return returnCode
 
     # from docker0dagster
     run_container_context = DockerContainerContext.create_for_run(
@@ -430,13 +432,23 @@ def gleanerio(context, mode, source):
         # container.start()
         # client.api.start(container=container.id)
         ## start is not working
-
-        for line in container.logs(stdout=True, stderr=True, stream=True, follow=True):
-            get_dagster_logger().debug(line)  # noqa: T201
+        try:
+            for line in container.logs(stdout=True, stderr=True, stream=True, follow=True):
+                get_dagster_logger().debug(line)  # noqa: T201
+        except docker.errors.APIError as ex:
+            get_dagster_logger().info(f"watch container logs failed Docker API ISSUE: ", ex)
+            returnCode = 1
+        except Exception as ex:
+            get_dagster_logger().info(f"watch container logs failed other issue: ", ex)
+            returnCode = 1
 
         # ## ------------  Wait expect 200
+        # we want to get the logs, no matter what, so do not exit, yet.
+        ## or should logs be moved into finally?
+        ### in which case they need to be methods that don't send back errors.
         exit_status = container.wait()["StatusCode"]
         get_dagster_logger().info(f"Container Wait Exit status:  {exit_status}")
+        returnCode = exit_status
 
 
 
@@ -444,7 +456,7 @@ def gleanerio(context, mode, source):
         ## ------------  Copy logs  expect 200
 
 
-        c = container.logs(stdout=True, stderr=True, stream=False, follow=True).decode('latin-1')
+        c = container.logs(stdout=True, stderr=True, stream=False, follow=False).decode('latin-1')
 
         # write to s3
 
@@ -489,65 +501,72 @@ def gleanerio(context, mode, source):
        #      i+=1
 
        # s3loader(r.read().decode('latin-1'), NAME)
-        s3loader(r.read(), f"{source}_{str(mode)}_runlogs")
+
     finally:
         if (not DEBUG) :
-            if (cid):
-                url = URL + 'containers/' + cid
-                req = request.Request(url, method="DELETE")
-                req.add_header('X-API-Key', APIKEY)
-                # req.add_header('content-type', 'application/json')
-                req.add_header('accept', 'application/json')
-                r = request.urlopen(req)
-                print(r.status)
+            # if (cid):
+            #     url = URL + 'containers/' + cid
+            #     req = request.Request(url, method="DELETE")
+            #     req.add_header('X-API-Key', APIKEY)
+            #     # req.add_header('content-type', 'application/json')
+            #     req.add_header('accept', 'application/json')
+            #     r = request.urlopen(req)
+            #     print(r.status)
+            #     get_dagster_logger().info(f"Container Remove: {str(r.status)}")
+            # else:
+            #     get_dagster_logger().info(f"Container Not created, so not removed.")
+            if (container):
+                container.remove(force=True)
                 get_dagster_logger().info(f"Container Remove: {str(r.status)}")
             else:
                 get_dagster_logger().info(f"Container Not created, so not removed.")
         else:
             get_dagster_logger().info(f"Container NOT Remove: DEBUG ENABLED")
 
-
-    return 0
+    if (returnCode != 0):
+        get_dagster_logger().info(f"Gleaner/Nabu container non-zero exit code. See logs in S3")
+        raise Exception("Gleaner/Nabu container non-zero exit code. See logs in S3")
+    return returnCode
 
 @op
-def usapdc_gleaner(context):
+def usapdc_gleaner(context)-> str:
     returned_value = gleanerio(context, ("gleaner"), "usapdc")
     r = str('returned value:{}'.format(returned_value))
     get_dagster_logger().info(f"Gleaner notes are  {r} ")
     return r
 
 @op
-def usapdc_nabu_prune(context, msg: str):
+def usapdc_nabu_prune(context, msg: str)-> str:
     returned_value = gleanerio(context,("nabu"), "usapdc")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def usapdc_nabuprov(context, msg: str):
+def usapdc_nabuprov(context, msg: str)-> str:
     returned_value = gleanerio(context,("prov"), "usapdc")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def usapdc_nabuorg(context, msg: str):
+def usapdc_nabuorg(context, msg: str)-> str:
     returned_value = gleanerio(context,("orgs"), "usapdc")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def usapdc_naburelease(context, msg: str):
+def usapdc_naburelease(context, msg: str) -> str:
     returned_value = gleanerio(context,("release"), "usapdc")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 @op
-def usapdc_uploadrelease(context, msg: str):
+def usapdc_uploadrelease(context, msg: str) -> str:
     returned_value = postRelease("usapdc")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 
 @op
-def usapdc_missingreport_s3(context, msg: str):
+def usapdc_missingreport_s3(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="usapdc")
     source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -562,7 +581,7 @@ def usapdc_missingreport_s3(context, msg: str):
     s3Minio.putReportFile(bucket, source_name, "missing_report_s3.json", report)
     return msg + r
 @op
-def usapdc_missingreport_graph(context, msg: str):
+def usapdc_missingreport_graph(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="usapdc")
     source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -581,7 +600,7 @@ def usapdc_missingreport_graph(context, msg: str):
 
     return msg + r
 @op
-def usapdc_graph_reports(context, msg: str):
+def usapdc_graph_reports(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="usapdc")
     #source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -601,7 +620,7 @@ def usapdc_graph_reports(context, msg: str):
     return msg + r
 
 @op
-def usapdc_identifier_stats(context, msg: str):
+def usapdc_identifier_stats(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="usapdc")
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
     bucket = GLEANER_MINIO_BUCKET
@@ -614,7 +633,8 @@ def usapdc_identifier_stats(context, msg: str):
     s3Minio.putReportFile(bucket, source_name, "identifier_stats.json", report)
     return msg + r
 
-def usapdc_bucket_urls(context, msg: str):
+@op()
+def usapdc_bucket_urls(context, msg: str) -> str:
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
     bucket = GLEANER_MINIO_BUCKET
     source_name = "usapdc"
@@ -648,7 +668,7 @@ def harvest_usapdc():
     report_ms3 = usapdc_missingreport_s3(harvest)
     report_idstat = usapdc_identifier_stats(report_ms3)
     # for some reason, this causes a msg parameter missing
-   # report_bucketurl = usapdc_bucket_urls(report_idstat)
+    report_bucketurl = usapdc_bucket_urls(report_idstat)
 
     #report1 = missingreport_s3(harvest, source="usapdc")
     load_release = usapdc_naburelease(harvest)

--- a/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_xdomes.py
+++ b/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_xdomes.py
@@ -227,7 +227,7 @@ def _create_container(
 
 def gleanerio(context, mode, source):
     ## ------------   Create
-
+    returnCode = 0
     get_dagster_logger().info(f"Gleanerio mode: {str(mode)}")
 
     if str(mode) == "gleaner":
@@ -277,7 +277,9 @@ def gleanerio(context, mode, source):
         Entrypoint = "nabu"
         # LOGFILE = 'log_nabu.txt'  # only used for local log file writing
     else:
-        return 1
+
+        returnCode = 1
+        return returnCode
 
     # from docker0dagster
     run_container_context = DockerContainerContext.create_for_run(
@@ -430,13 +432,23 @@ def gleanerio(context, mode, source):
         # container.start()
         # client.api.start(container=container.id)
         ## start is not working
-
-        for line in container.logs(stdout=True, stderr=True, stream=True, follow=True):
-            get_dagster_logger().debug(line)  # noqa: T201
+        try:
+            for line in container.logs(stdout=True, stderr=True, stream=True, follow=True):
+                get_dagster_logger().debug(line)  # noqa: T201
+        except docker.errors.APIError as ex:
+            get_dagster_logger().info(f"watch container logs failed Docker API ISSUE: ", ex)
+            returnCode = 1
+        except Exception as ex:
+            get_dagster_logger().info(f"watch container logs failed other issue: ", ex)
+            returnCode = 1
 
         # ## ------------  Wait expect 200
+        # we want to get the logs, no matter what, so do not exit, yet.
+        ## or should logs be moved into finally?
+        ### in which case they need to be methods that don't send back errors.
         exit_status = container.wait()["StatusCode"]
         get_dagster_logger().info(f"Container Wait Exit status:  {exit_status}")
+        returnCode = exit_status
 
 
 
@@ -444,7 +456,7 @@ def gleanerio(context, mode, source):
         ## ------------  Copy logs  expect 200
 
 
-        c = container.logs(stdout=True, stderr=True, stream=False, follow=True).decode('latin-1')
+        c = container.logs(stdout=True, stderr=True, stream=False, follow=False).decode('latin-1')
 
         # write to s3
 
@@ -489,65 +501,72 @@ def gleanerio(context, mode, source):
        #      i+=1
 
        # s3loader(r.read().decode('latin-1'), NAME)
-        s3loader(r.read(), f"{source}_{str(mode)}_runlogs")
+
     finally:
         if (not DEBUG) :
-            if (cid):
-                url = URL + 'containers/' + cid
-                req = request.Request(url, method="DELETE")
-                req.add_header('X-API-Key', APIKEY)
-                # req.add_header('content-type', 'application/json')
-                req.add_header('accept', 'application/json')
-                r = request.urlopen(req)
-                print(r.status)
+            # if (cid):
+            #     url = URL + 'containers/' + cid
+            #     req = request.Request(url, method="DELETE")
+            #     req.add_header('X-API-Key', APIKEY)
+            #     # req.add_header('content-type', 'application/json')
+            #     req.add_header('accept', 'application/json')
+            #     r = request.urlopen(req)
+            #     print(r.status)
+            #     get_dagster_logger().info(f"Container Remove: {str(r.status)}")
+            # else:
+            #     get_dagster_logger().info(f"Container Not created, so not removed.")
+            if (container):
+                container.remove(force=True)
                 get_dagster_logger().info(f"Container Remove: {str(r.status)}")
             else:
                 get_dagster_logger().info(f"Container Not created, so not removed.")
         else:
             get_dagster_logger().info(f"Container NOT Remove: DEBUG ENABLED")
 
-
-    return 0
+    if (returnCode != 0):
+        get_dagster_logger().info(f"Gleaner/Nabu container non-zero exit code. See logs in S3")
+        raise Exception("Gleaner/Nabu container non-zero exit code. See logs in S3")
+    return returnCode
 
 @op
-def xdomes_gleaner(context):
+def xdomes_gleaner(context)-> str:
     returned_value = gleanerio(context, ("gleaner"), "xdomes")
     r = str('returned value:{}'.format(returned_value))
     get_dagster_logger().info(f"Gleaner notes are  {r} ")
     return r
 
 @op
-def xdomes_nabu_prune(context, msg: str):
+def xdomes_nabu_prune(context, msg: str)-> str:
     returned_value = gleanerio(context,("nabu"), "xdomes")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def xdomes_nabuprov(context, msg: str):
+def xdomes_nabuprov(context, msg: str)-> str:
     returned_value = gleanerio(context,("prov"), "xdomes")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def xdomes_nabuorg(context, msg: str):
+def xdomes_nabuorg(context, msg: str)-> str:
     returned_value = gleanerio(context,("orgs"), "xdomes")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 @op
-def xdomes_naburelease(context, msg: str):
+def xdomes_naburelease(context, msg: str) -> str:
     returned_value = gleanerio(context,("release"), "xdomes")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 @op
-def xdomes_uploadrelease(context, msg: str):
+def xdomes_uploadrelease(context, msg: str) -> str:
     returned_value = postRelease("xdomes")
     r = str('returned value:{}'.format(returned_value))
     return msg + r
 
 
 @op
-def xdomes_missingreport_s3(context, msg: str):
+def xdomes_missingreport_s3(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="xdomes")
     source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -562,7 +581,7 @@ def xdomes_missingreport_s3(context, msg: str):
     s3Minio.putReportFile(bucket, source_name, "missing_report_s3.json", report)
     return msg + r
 @op
-def xdomes_missingreport_graph(context, msg: str):
+def xdomes_missingreport_graph(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="xdomes")
     source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -581,7 +600,7 @@ def xdomes_missingreport_graph(context, msg: str):
 
     return msg + r
 @op
-def xdomes_graph_reports(context, msg: str):
+def xdomes_graph_reports(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="xdomes")
     #source_url = source.get('url')
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
@@ -601,7 +620,7 @@ def xdomes_graph_reports(context, msg: str):
     return msg + r
 
 @op
-def xdomes_identifier_stats(context, msg: str):
+def xdomes_identifier_stats(context, msg: str) -> str:
     source = getSitemapSourcesFromGleaner("/scheduler/gleanerconfig.yaml", sourcename="xdomes")
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
     bucket = GLEANER_MINIO_BUCKET
@@ -614,7 +633,8 @@ def xdomes_identifier_stats(context, msg: str):
     s3Minio.putReportFile(bucket, source_name, "identifier_stats.json", report)
     return msg + r
 
-def xdomes_bucket_urls(context, msg: str):
+@op()
+def xdomes_bucket_urls(context, msg: str) -> str:
     s3Minio = s3.MinioDatastore(_pythonMinioUrl(GLEANER_MINIO_ADDRESS), None)
     bucket = GLEANER_MINIO_BUCKET
     source_name = "xdomes"
@@ -648,7 +668,7 @@ def harvest_xdomes():
     report_ms3 = xdomes_missingreport_s3(harvest)
     report_idstat = xdomes_identifier_stats(report_ms3)
     # for some reason, this causes a msg parameter missing
-   # report_bucketurl = xdomes_bucket_urls(report_idstat)
+    report_bucketurl = xdomes_bucket_urls(report_idstat)
 
     #report1 = missingreport_s3(harvest, source="xdomes")
     load_release = xdomes_naburelease(harvest)


### PR DESCRIPTION
Gleaner dev_ec container now sends non-zero exit codes when misconfigured.

This stops the run when such exit codes happen.

generated code updated, too 