### PR TITLE
read release files for graph reports

### DIFF
--- a/dagster/implnets/deployment/envFile.env
+++ b/dagster/implnets/deployment/envFile.env
@@ -62,4 +62,5 @@ GLEANERIO_GRAPH_NAMESPACE=
 # example: https://graph.geocodes.ncsa.illinois.edu/blazegraph/namespace/yyearthcube2/sparql
 #graph endpoint will be GLEANERIO_GRAPH_URL
 GLEANERIO_SUMMARY_GRAPH_NAMESPACE=
+GLEANERIO_SUMMARIZE_GRAPH=False
 

--- a/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_amgeo.py
+++ b/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_amgeo.py
@@ -12,10 +12,12 @@ from docker.types import RestartPolicy, ServiceMode
 from ec.gleanerio.gleaner import getGleaner, getSitemapSourcesFromGleaner, endpointUpdateNamespace
 import json
 
+from ec.graph.release_graph import ReleaseGraph
 from minio import Minio
 from minio.error import S3Error
 from datetime import datetime
-from ec.reporting.report import missingReport, generateGraphReportsRepo, reportTypes, generateIdentifierRepo
+from ec.reporting.report import missingReport, generateGraphReportsRepo, reportTypes, generateIdentifierRepo, \
+    generateGraphReportsRelease
 from ec.datastore import s3
 from ec.summarize import summaryDF2ttl, get_summary4graph, get_summary4repoSubset
 from ec.graph.manageGraph import ManageBlazegraph as mg
@@ -81,6 +83,7 @@ GLEANERIO_GLEANER_DOCKER_CONFIG=str(os.environ.get('GLEANERIO_GLEANER_DOCKER_CON
 GLEANERIO_NABU_DOCKER_CONFIG=str(os.environ.get('GLEANERIO_NABU_DOCKER_CONFIG', 'nabu'))
 #GLEANERIO_SUMMARY_GRAPH_ENDPOINT = os.environ.get('GLEANERIO_SUMMARY_GRAPH_ENDPOINT')
 GLEANERIO_SUMMARY_GRAPH_NAMESPACE = os.environ.get('GLEANERIO_SUMMARY_GRAPH_NAMESPACE',f"{GLEANER_GRAPH_NAMESPACE}_summary" )
+GLEANERIO_SUMMARIZE_GRAPH=(os.getenv('GLEANERIO_SUMMARIZE_GRAPH', 'False').lower()  == 'true')
 
 SUMMARY_PATH = 'graphs/summary'
 RELEASE_PATH = 'graphs/latest'
@@ -174,17 +177,28 @@ def s3loader(data, name):
                       content_type="text/plain"
                          )
     get_dagster_logger().info(f"Log uploaded: {str(objPrefix)}")
-def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_graphEndpoint()):
-    # revision of EC utilities, will have a insertFromURL
-    #instance =  mg.ManageBlazegraph(os.environ.get('GLEANER_GRAPH_URL'),os.environ.get('GLEANER_GRAPH_NAMESPACE') )
-    proto = "http"
 
+def _releaseUrl( source, path=RELEASE_PATH, extension="nq"):
+    proto = "http"
     if GLEANER_MINIO_USE_SSL:
         proto = "https"
-    port = GLEANER_MINIO_PORT
     address = _pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT)
     bucket = GLEANER_MINIO_BUCKET
     release_url = f"{proto}://{address}/{bucket}/{path}/{source}_release.{extension}"
+    return release_url
+
+def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_graphEndpoint()):
+    # revision of EC utilities, will have a insertFromURL
+    #instance =  mg.ManageBlazegraph(os.environ.get('GLEANER_GRAPH_URL'),os.environ.get('GLEANER_GRAPH_NAMESPACE') )
+    # proto = "http"
+    #
+    # if GLEANER_MINIO_USE_SSL:
+    #     proto = "https"
+    # port = GLEANER_MINIO_PORT
+    # address = _pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT)
+    # bucket = GLEANER_MINIO_BUCKET
+    # release_url = f"{proto}://{address}/{bucket}/{path}/{source}_release.{extension}"
+
     # BLAZEGRAPH SPECIFIC
     # url = f"{_graphEndpoint()}?uri={release_url}"  # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql?uri={release_url}"
     # get_dagster_logger().info(f'graph: insert "{source}" to {url} ')
@@ -201,6 +215,7 @@ def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_grap
     #     get_dagster_logger().info(f'graph: error')
     #     raise Exception(f' graph: insert failed: status:{r.status_code}')
 
+    release_url = _releaseUrl(source, path, extension)
     ### GENERIC LOAD FROM
     url = f"{graphendpoint}" # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql?uri={release_url}"
     get_dagster_logger().info(f'graph: insert "{source}" to {url} ')
@@ -685,9 +700,10 @@ def amgeo_graph_reports(context) :
 
     graphendpoint = _graphEndpoint() # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql"
 
-    milled = False
-    summon = True
-    returned_value = generateGraphReportsRepo(source_name,  graphendpoint, reportList=reportTypes["repo_detailed"])
+
+    #returned_value = generateGraphReportsRepo(source_name,  graphendpoint, reportList=reportTypes["repo_detailed"])
+    s3FileUrl = _releaseUrl(source_name )
+    returned_value = generateGraphReportsRelease(source_name,s3FileUrl)
     r = str('returned value:{}'.format(returned_value))
     #report = json.dumps(returned_value, indent=2) # value already json.dumps
     report = returned_value
@@ -738,7 +754,13 @@ def amgeo_summarize(context) :
 
     try:
 
-        summarydf = get_summary4repoSubset(endpoint, source_name)
+       # summarydf = get_summary4repoSubset(endpoint, source_name)
+        rg = ReleaseGraph()
+        rg.read_release(_pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT),
+                        bucket,
+                        source_name,
+                        options=MINIO_OPTIONS)
+        summarydf = rg.summarize()
         nt, g = summaryDF2ttl(summarydf, source_name)  # let's try the new generator
         summaryttl = g.serialize(format='longturtle')
         # Lets always write out file to s3, and insert as a separate process
@@ -791,10 +813,11 @@ def harvest_amgeo():
 # defingin nothing dependencies
     # https://docs.dagster.io/concepts/ops-jobs-graphs/graphs#defining-nothing-dependencies
 
-    report_ms3 = amgeo_missingreport_s3(start=harvest)
+    report_bucketurl = amgeo_bucket_urls(start=harvest)
+    report_ms3 = amgeo_missingreport_s3(start=report_bucketurl)
     report_idstat = amgeo_identifier_stats(start=report_ms3)
     # for some reason, this causes a msg parameter missing
-    report_bucketurl = amgeo_bucket_urls(start=report_idstat)
+
 
     #report1 = missingreport_s3(harvest, source="amgeo")
     load_release = amgeo_naburelease(start=harvest)
@@ -804,11 +827,14 @@ def harvest_amgeo():
     load_prov = amgeo_nabuprov(start=load_prune)
     load_org = amgeo_nabuorg(start=load_prov)
 
-    summarize = amgeo_summarize(start=load_uploadrelease)
-    upload_summarize = amgeo_upload_summarize(start=summarize)
+    if(GLEANERIO_SUMMARIZE_GRAPH):
+        summarize = amgeo_summarize(start=load_uploadrelease)
+        upload_summarize = amgeo_upload_summarize(start=summarize)
+
+
 
 # run after load
-    report_msgraph = amgeo_missingreport_graph(start=summarize)
+    report_msgraph = amgeo_missingreport_graph(start=load_prov)
     report_graph = amgeo_graph_reports(start=report_msgraph)
 
 

--- a/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_aquadocs.py
+++ b/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_aquadocs.py
@@ -12,10 +12,12 @@ from docker.types import RestartPolicy, ServiceMode
 from ec.gleanerio.gleaner import getGleaner, getSitemapSourcesFromGleaner, endpointUpdateNamespace
 import json
 
+from ec.graph.release_graph import ReleaseGraph
 from minio import Minio
 from minio.error import S3Error
 from datetime import datetime
-from ec.reporting.report import missingReport, generateGraphReportsRepo, reportTypes, generateIdentifierRepo
+from ec.reporting.report import missingReport, generateGraphReportsRepo, reportTypes, generateIdentifierRepo, \
+    generateGraphReportsRelease
 from ec.datastore import s3
 from ec.summarize import summaryDF2ttl, get_summary4graph, get_summary4repoSubset
 from ec.graph.manageGraph import ManageBlazegraph as mg
@@ -81,6 +83,7 @@ GLEANERIO_GLEANER_DOCKER_CONFIG=str(os.environ.get('GLEANERIO_GLEANER_DOCKER_CON
 GLEANERIO_NABU_DOCKER_CONFIG=str(os.environ.get('GLEANERIO_NABU_DOCKER_CONFIG', 'nabu'))
 #GLEANERIO_SUMMARY_GRAPH_ENDPOINT = os.environ.get('GLEANERIO_SUMMARY_GRAPH_ENDPOINT')
 GLEANERIO_SUMMARY_GRAPH_NAMESPACE = os.environ.get('GLEANERIO_SUMMARY_GRAPH_NAMESPACE',f"{GLEANER_GRAPH_NAMESPACE}_summary" )
+GLEANERIO_SUMMARIZE_GRAPH=(os.getenv('GLEANERIO_SUMMARIZE_GRAPH', 'False').lower()  == 'true')
 
 SUMMARY_PATH = 'graphs/summary'
 RELEASE_PATH = 'graphs/latest'
@@ -174,17 +177,28 @@ def s3loader(data, name):
                       content_type="text/plain"
                          )
     get_dagster_logger().info(f"Log uploaded: {str(objPrefix)}")
-def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_graphEndpoint()):
-    # revision of EC utilities, will have a insertFromURL
-    #instance =  mg.ManageBlazegraph(os.environ.get('GLEANER_GRAPH_URL'),os.environ.get('GLEANER_GRAPH_NAMESPACE') )
-    proto = "http"
 
+def _releaseUrl( source, path=RELEASE_PATH, extension="nq"):
+    proto = "http"
     if GLEANER_MINIO_USE_SSL:
         proto = "https"
-    port = GLEANER_MINIO_PORT
     address = _pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT)
     bucket = GLEANER_MINIO_BUCKET
     release_url = f"{proto}://{address}/{bucket}/{path}/{source}_release.{extension}"
+    return release_url
+
+def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_graphEndpoint()):
+    # revision of EC utilities, will have a insertFromURL
+    #instance =  mg.ManageBlazegraph(os.environ.get('GLEANER_GRAPH_URL'),os.environ.get('GLEANER_GRAPH_NAMESPACE') )
+    # proto = "http"
+    #
+    # if GLEANER_MINIO_USE_SSL:
+    #     proto = "https"
+    # port = GLEANER_MINIO_PORT
+    # address = _pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT)
+    # bucket = GLEANER_MINIO_BUCKET
+    # release_url = f"{proto}://{address}/{bucket}/{path}/{source}_release.{extension}"
+
     # BLAZEGRAPH SPECIFIC
     # url = f"{_graphEndpoint()}?uri={release_url}"  # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql?uri={release_url}"
     # get_dagster_logger().info(f'graph: insert "{source}" to {url} ')
@@ -201,6 +215,7 @@ def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_grap
     #     get_dagster_logger().info(f'graph: error')
     #     raise Exception(f' graph: insert failed: status:{r.status_code}')
 
+    release_url = _releaseUrl(source, path, extension)
     ### GENERIC LOAD FROM
     url = f"{graphendpoint}" # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql?uri={release_url}"
     get_dagster_logger().info(f'graph: insert "{source}" to {url} ')
@@ -685,9 +700,10 @@ def aquadocs_graph_reports(context) :
 
     graphendpoint = _graphEndpoint() # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql"
 
-    milled = False
-    summon = True
-    returned_value = generateGraphReportsRepo(source_name,  graphendpoint, reportList=reportTypes["repo_detailed"])
+
+    #returned_value = generateGraphReportsRepo(source_name,  graphendpoint, reportList=reportTypes["repo_detailed"])
+    s3FileUrl = _releaseUrl(source_name )
+    returned_value = generateGraphReportsRelease(source_name,s3FileUrl)
     r = str('returned value:{}'.format(returned_value))
     #report = json.dumps(returned_value, indent=2) # value already json.dumps
     report = returned_value
@@ -738,7 +754,13 @@ def aquadocs_summarize(context) :
 
     try:
 
-        summarydf = get_summary4repoSubset(endpoint, source_name)
+       # summarydf = get_summary4repoSubset(endpoint, source_name)
+        rg = ReleaseGraph()
+        rg.read_release(_pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT),
+                        bucket,
+                        source_name,
+                        options=MINIO_OPTIONS)
+        summarydf = rg.summarize()
         nt, g = summaryDF2ttl(summarydf, source_name)  # let's try the new generator
         summaryttl = g.serialize(format='longturtle')
         # Lets always write out file to s3, and insert as a separate process
@@ -791,10 +813,11 @@ def harvest_aquadocs():
 # defingin nothing dependencies
     # https://docs.dagster.io/concepts/ops-jobs-graphs/graphs#defining-nothing-dependencies
 
-    report_ms3 = aquadocs_missingreport_s3(start=harvest)
+    report_bucketurl = aquadocs_bucket_urls(start=harvest)
+    report_ms3 = aquadocs_missingreport_s3(start=report_bucketurl)
     report_idstat = aquadocs_identifier_stats(start=report_ms3)
     # for some reason, this causes a msg parameter missing
-    report_bucketurl = aquadocs_bucket_urls(start=report_idstat)
+
 
     #report1 = missingreport_s3(harvest, source="aquadocs")
     load_release = aquadocs_naburelease(start=harvest)
@@ -804,11 +827,14 @@ def harvest_aquadocs():
     load_prov = aquadocs_nabuprov(start=load_prune)
     load_org = aquadocs_nabuorg(start=load_prov)
 
-    summarize = aquadocs_summarize(start=load_uploadrelease)
-    upload_summarize = aquadocs_upload_summarize(start=summarize)
+    if(GLEANERIO_SUMMARIZE_GRAPH):
+        summarize = aquadocs_summarize(start=load_uploadrelease)
+        upload_summarize = aquadocs_upload_summarize(start=summarize)
+
+
 
 # run after load
-    report_msgraph = aquadocs_missingreport_graph(start=summarize)
+    report_msgraph = aquadocs_missingreport_graph(start=load_prov)
     report_graph = aquadocs_graph_reports(start=report_msgraph)
 
 

--- a/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_bcodmo.py
+++ b/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_bcodmo.py
@@ -12,10 +12,12 @@ from docker.types import RestartPolicy, ServiceMode
 from ec.gleanerio.gleaner import getGleaner, getSitemapSourcesFromGleaner, endpointUpdateNamespace
 import json
 
+from ec.graph.release_graph import ReleaseGraph
 from minio import Minio
 from minio.error import S3Error
 from datetime import datetime
-from ec.reporting.report import missingReport, generateGraphReportsRepo, reportTypes, generateIdentifierRepo
+from ec.reporting.report import missingReport, generateGraphReportsRepo, reportTypes, generateIdentifierRepo, \
+    generateGraphReportsRelease
 from ec.datastore import s3
 from ec.summarize import summaryDF2ttl, get_summary4graph, get_summary4repoSubset
 from ec.graph.manageGraph import ManageBlazegraph as mg
@@ -81,6 +83,7 @@ GLEANERIO_GLEANER_DOCKER_CONFIG=str(os.environ.get('GLEANERIO_GLEANER_DOCKER_CON
 GLEANERIO_NABU_DOCKER_CONFIG=str(os.environ.get('GLEANERIO_NABU_DOCKER_CONFIG', 'nabu'))
 #GLEANERIO_SUMMARY_GRAPH_ENDPOINT = os.environ.get('GLEANERIO_SUMMARY_GRAPH_ENDPOINT')
 GLEANERIO_SUMMARY_GRAPH_NAMESPACE = os.environ.get('GLEANERIO_SUMMARY_GRAPH_NAMESPACE',f"{GLEANER_GRAPH_NAMESPACE}_summary" )
+GLEANERIO_SUMMARIZE_GRAPH=(os.getenv('GLEANERIO_SUMMARIZE_GRAPH', 'False').lower()  == 'true')
 
 SUMMARY_PATH = 'graphs/summary'
 RELEASE_PATH = 'graphs/latest'
@@ -174,17 +177,28 @@ def s3loader(data, name):
                       content_type="text/plain"
                          )
     get_dagster_logger().info(f"Log uploaded: {str(objPrefix)}")
-def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_graphEndpoint()):
-    # revision of EC utilities, will have a insertFromURL
-    #instance =  mg.ManageBlazegraph(os.environ.get('GLEANER_GRAPH_URL'),os.environ.get('GLEANER_GRAPH_NAMESPACE') )
-    proto = "http"
 
+def _releaseUrl( source, path=RELEASE_PATH, extension="nq"):
+    proto = "http"
     if GLEANER_MINIO_USE_SSL:
         proto = "https"
-    port = GLEANER_MINIO_PORT
     address = _pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT)
     bucket = GLEANER_MINIO_BUCKET
     release_url = f"{proto}://{address}/{bucket}/{path}/{source}_release.{extension}"
+    return release_url
+
+def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_graphEndpoint()):
+    # revision of EC utilities, will have a insertFromURL
+    #instance =  mg.ManageBlazegraph(os.environ.get('GLEANER_GRAPH_URL'),os.environ.get('GLEANER_GRAPH_NAMESPACE') )
+    # proto = "http"
+    #
+    # if GLEANER_MINIO_USE_SSL:
+    #     proto = "https"
+    # port = GLEANER_MINIO_PORT
+    # address = _pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT)
+    # bucket = GLEANER_MINIO_BUCKET
+    # release_url = f"{proto}://{address}/{bucket}/{path}/{source}_release.{extension}"
+
     # BLAZEGRAPH SPECIFIC
     # url = f"{_graphEndpoint()}?uri={release_url}"  # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql?uri={release_url}"
     # get_dagster_logger().info(f'graph: insert "{source}" to {url} ')
@@ -201,6 +215,7 @@ def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_grap
     #     get_dagster_logger().info(f'graph: error')
     #     raise Exception(f' graph: insert failed: status:{r.status_code}')
 
+    release_url = _releaseUrl(source, path, extension)
     ### GENERIC LOAD FROM
     url = f"{graphendpoint}" # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql?uri={release_url}"
     get_dagster_logger().info(f'graph: insert "{source}" to {url} ')
@@ -685,9 +700,10 @@ def bcodmo_graph_reports(context) :
 
     graphendpoint = _graphEndpoint() # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql"
 
-    milled = False
-    summon = True
-    returned_value = generateGraphReportsRepo(source_name,  graphendpoint, reportList=reportTypes["repo_detailed"])
+
+    #returned_value = generateGraphReportsRepo(source_name,  graphendpoint, reportList=reportTypes["repo_detailed"])
+    s3FileUrl = _releaseUrl(source_name )
+    returned_value = generateGraphReportsRelease(source_name,s3FileUrl)
     r = str('returned value:{}'.format(returned_value))
     #report = json.dumps(returned_value, indent=2) # value already json.dumps
     report = returned_value
@@ -738,7 +754,13 @@ def bcodmo_summarize(context) :
 
     try:
 
-        summarydf = get_summary4repoSubset(endpoint, source_name)
+       # summarydf = get_summary4repoSubset(endpoint, source_name)
+        rg = ReleaseGraph()
+        rg.read_release(_pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT),
+                        bucket,
+                        source_name,
+                        options=MINIO_OPTIONS)
+        summarydf = rg.summarize()
         nt, g = summaryDF2ttl(summarydf, source_name)  # let's try the new generator
         summaryttl = g.serialize(format='longturtle')
         # Lets always write out file to s3, and insert as a separate process
@@ -791,10 +813,11 @@ def harvest_bcodmo():
 # defingin nothing dependencies
     # https://docs.dagster.io/concepts/ops-jobs-graphs/graphs#defining-nothing-dependencies
 
-    report_ms3 = bcodmo_missingreport_s3(start=harvest)
+    report_bucketurl = bcodmo_bucket_urls(start=harvest)
+    report_ms3 = bcodmo_missingreport_s3(start=report_bucketurl)
     report_idstat = bcodmo_identifier_stats(start=report_ms3)
     # for some reason, this causes a msg parameter missing
-    report_bucketurl = bcodmo_bucket_urls(start=report_idstat)
+
 
     #report1 = missingreport_s3(harvest, source="bcodmo")
     load_release = bcodmo_naburelease(start=harvest)
@@ -804,11 +827,14 @@ def harvest_bcodmo():
     load_prov = bcodmo_nabuprov(start=load_prune)
     load_org = bcodmo_nabuorg(start=load_prov)
 
-    summarize = bcodmo_summarize(start=load_uploadrelease)
-    upload_summarize = bcodmo_upload_summarize(start=summarize)
+    if(GLEANERIO_SUMMARIZE_GRAPH):
+        summarize = bcodmo_summarize(start=load_uploadrelease)
+        upload_summarize = bcodmo_upload_summarize(start=summarize)
+
+
 
 # run after load
-    report_msgraph = bcodmo_missingreport_graph(start=summarize)
+    report_msgraph = bcodmo_missingreport_graph(start=load_prov)
     report_graph = bcodmo_graph_reports(start=report_msgraph)
 
 

--- a/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_cchdo.py
+++ b/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_cchdo.py
@@ -12,10 +12,12 @@ from docker.types import RestartPolicy, ServiceMode
 from ec.gleanerio.gleaner import getGleaner, getSitemapSourcesFromGleaner, endpointUpdateNamespace
 import json
 
+from ec.graph.release_graph import ReleaseGraph
 from minio import Minio
 from minio.error import S3Error
 from datetime import datetime
-from ec.reporting.report import missingReport, generateGraphReportsRepo, reportTypes, generateIdentifierRepo
+from ec.reporting.report import missingReport, generateGraphReportsRepo, reportTypes, generateIdentifierRepo, \
+    generateGraphReportsRelease
 from ec.datastore import s3
 from ec.summarize import summaryDF2ttl, get_summary4graph, get_summary4repoSubset
 from ec.graph.manageGraph import ManageBlazegraph as mg
@@ -81,6 +83,7 @@ GLEANERIO_GLEANER_DOCKER_CONFIG=str(os.environ.get('GLEANERIO_GLEANER_DOCKER_CON
 GLEANERIO_NABU_DOCKER_CONFIG=str(os.environ.get('GLEANERIO_NABU_DOCKER_CONFIG', 'nabu'))
 #GLEANERIO_SUMMARY_GRAPH_ENDPOINT = os.environ.get('GLEANERIO_SUMMARY_GRAPH_ENDPOINT')
 GLEANERIO_SUMMARY_GRAPH_NAMESPACE = os.environ.get('GLEANERIO_SUMMARY_GRAPH_NAMESPACE',f"{GLEANER_GRAPH_NAMESPACE}_summary" )
+GLEANERIO_SUMMARIZE_GRAPH=(os.getenv('GLEANERIO_SUMMARIZE_GRAPH', 'False').lower()  == 'true')
 
 SUMMARY_PATH = 'graphs/summary'
 RELEASE_PATH = 'graphs/latest'
@@ -174,17 +177,28 @@ def s3loader(data, name):
                       content_type="text/plain"
                          )
     get_dagster_logger().info(f"Log uploaded: {str(objPrefix)}")
-def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_graphEndpoint()):
-    # revision of EC utilities, will have a insertFromURL
-    #instance =  mg.ManageBlazegraph(os.environ.get('GLEANER_GRAPH_URL'),os.environ.get('GLEANER_GRAPH_NAMESPACE') )
-    proto = "http"
 
+def _releaseUrl( source, path=RELEASE_PATH, extension="nq"):
+    proto = "http"
     if GLEANER_MINIO_USE_SSL:
         proto = "https"
-    port = GLEANER_MINIO_PORT
     address = _pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT)
     bucket = GLEANER_MINIO_BUCKET
     release_url = f"{proto}://{address}/{bucket}/{path}/{source}_release.{extension}"
+    return release_url
+
+def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_graphEndpoint()):
+    # revision of EC utilities, will have a insertFromURL
+    #instance =  mg.ManageBlazegraph(os.environ.get('GLEANER_GRAPH_URL'),os.environ.get('GLEANER_GRAPH_NAMESPACE') )
+    # proto = "http"
+    #
+    # if GLEANER_MINIO_USE_SSL:
+    #     proto = "https"
+    # port = GLEANER_MINIO_PORT
+    # address = _pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT)
+    # bucket = GLEANER_MINIO_BUCKET
+    # release_url = f"{proto}://{address}/{bucket}/{path}/{source}_release.{extension}"
+
     # BLAZEGRAPH SPECIFIC
     # url = f"{_graphEndpoint()}?uri={release_url}"  # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql?uri={release_url}"
     # get_dagster_logger().info(f'graph: insert "{source}" to {url} ')
@@ -201,6 +215,7 @@ def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_grap
     #     get_dagster_logger().info(f'graph: error')
     #     raise Exception(f' graph: insert failed: status:{r.status_code}')
 
+    release_url = _releaseUrl(source, path, extension)
     ### GENERIC LOAD FROM
     url = f"{graphendpoint}" # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql?uri={release_url}"
     get_dagster_logger().info(f'graph: insert "{source}" to {url} ')
@@ -685,9 +700,10 @@ def cchdo_graph_reports(context) :
 
     graphendpoint = _graphEndpoint() # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql"
 
-    milled = False
-    summon = True
-    returned_value = generateGraphReportsRepo(source_name,  graphendpoint, reportList=reportTypes["repo_detailed"])
+
+    #returned_value = generateGraphReportsRepo(source_name,  graphendpoint, reportList=reportTypes["repo_detailed"])
+    s3FileUrl = _releaseUrl(source_name )
+    returned_value = generateGraphReportsRelease(source_name,s3FileUrl)
     r = str('returned value:{}'.format(returned_value))
     #report = json.dumps(returned_value, indent=2) # value already json.dumps
     report = returned_value
@@ -738,7 +754,13 @@ def cchdo_summarize(context) :
 
     try:
 
-        summarydf = get_summary4repoSubset(endpoint, source_name)
+       # summarydf = get_summary4repoSubset(endpoint, source_name)
+        rg = ReleaseGraph()
+        rg.read_release(_pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT),
+                        bucket,
+                        source_name,
+                        options=MINIO_OPTIONS)
+        summarydf = rg.summarize()
         nt, g = summaryDF2ttl(summarydf, source_name)  # let's try the new generator
         summaryttl = g.serialize(format='longturtle')
         # Lets always write out file to s3, and insert as a separate process
@@ -791,10 +813,11 @@ def harvest_cchdo():
 # defingin nothing dependencies
     # https://docs.dagster.io/concepts/ops-jobs-graphs/graphs#defining-nothing-dependencies
 
-    report_ms3 = cchdo_missingreport_s3(start=harvest)
+    report_bucketurl = cchdo_bucket_urls(start=harvest)
+    report_ms3 = cchdo_missingreport_s3(start=report_bucketurl)
     report_idstat = cchdo_identifier_stats(start=report_ms3)
     # for some reason, this causes a msg parameter missing
-    report_bucketurl = cchdo_bucket_urls(start=report_idstat)
+
 
     #report1 = missingreport_s3(harvest, source="cchdo")
     load_release = cchdo_naburelease(start=harvest)
@@ -804,11 +827,14 @@ def harvest_cchdo():
     load_prov = cchdo_nabuprov(start=load_prune)
     load_org = cchdo_nabuorg(start=load_prov)
 
-    summarize = cchdo_summarize(start=load_uploadrelease)
-    upload_summarize = cchdo_upload_summarize(start=summarize)
+    if(GLEANERIO_SUMMARIZE_GRAPH):
+        summarize = cchdo_summarize(start=load_uploadrelease)
+        upload_summarize = cchdo_upload_summarize(start=summarize)
+
+
 
 # run after load
-    report_msgraph = cchdo_missingreport_graph(start=summarize)
+    report_msgraph = cchdo_missingreport_graph(start=load_prov)
     report_graph = cchdo_graph_reports(start=report_msgraph)
 
 

--- a/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_datadiscoverystudio.py
+++ b/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_datadiscoverystudio.py
@@ -12,10 +12,12 @@ from docker.types import RestartPolicy, ServiceMode
 from ec.gleanerio.gleaner import getGleaner, getSitemapSourcesFromGleaner, endpointUpdateNamespace
 import json
 
+from ec.graph.release_graph import ReleaseGraph
 from minio import Minio
 from minio.error import S3Error
 from datetime import datetime
-from ec.reporting.report import missingReport, generateGraphReportsRepo, reportTypes, generateIdentifierRepo
+from ec.reporting.report import missingReport, generateGraphReportsRepo, reportTypes, generateIdentifierRepo, \
+    generateGraphReportsRelease
 from ec.datastore import s3
 from ec.summarize import summaryDF2ttl, get_summary4graph, get_summary4repoSubset
 from ec.graph.manageGraph import ManageBlazegraph as mg
@@ -81,6 +83,7 @@ GLEANERIO_GLEANER_DOCKER_CONFIG=str(os.environ.get('GLEANERIO_GLEANER_DOCKER_CON
 GLEANERIO_NABU_DOCKER_CONFIG=str(os.environ.get('GLEANERIO_NABU_DOCKER_CONFIG', 'nabu'))
 #GLEANERIO_SUMMARY_GRAPH_ENDPOINT = os.environ.get('GLEANERIO_SUMMARY_GRAPH_ENDPOINT')
 GLEANERIO_SUMMARY_GRAPH_NAMESPACE = os.environ.get('GLEANERIO_SUMMARY_GRAPH_NAMESPACE',f"{GLEANER_GRAPH_NAMESPACE}_summary" )
+GLEANERIO_SUMMARIZE_GRAPH=(os.getenv('GLEANERIO_SUMMARIZE_GRAPH', 'False').lower()  == 'true')
 
 SUMMARY_PATH = 'graphs/summary'
 RELEASE_PATH = 'graphs/latest'
@@ -174,17 +177,28 @@ def s3loader(data, name):
                       content_type="text/plain"
                          )
     get_dagster_logger().info(f"Log uploaded: {str(objPrefix)}")
-def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_graphEndpoint()):
-    # revision of EC utilities, will have a insertFromURL
-    #instance =  mg.ManageBlazegraph(os.environ.get('GLEANER_GRAPH_URL'),os.environ.get('GLEANER_GRAPH_NAMESPACE') )
-    proto = "http"
 
+def _releaseUrl( source, path=RELEASE_PATH, extension="nq"):
+    proto = "http"
     if GLEANER_MINIO_USE_SSL:
         proto = "https"
-    port = GLEANER_MINIO_PORT
     address = _pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT)
     bucket = GLEANER_MINIO_BUCKET
     release_url = f"{proto}://{address}/{bucket}/{path}/{source}_release.{extension}"
+    return release_url
+
+def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_graphEndpoint()):
+    # revision of EC utilities, will have a insertFromURL
+    #instance =  mg.ManageBlazegraph(os.environ.get('GLEANER_GRAPH_URL'),os.environ.get('GLEANER_GRAPH_NAMESPACE') )
+    # proto = "http"
+    #
+    # if GLEANER_MINIO_USE_SSL:
+    #     proto = "https"
+    # port = GLEANER_MINIO_PORT
+    # address = _pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT)
+    # bucket = GLEANER_MINIO_BUCKET
+    # release_url = f"{proto}://{address}/{bucket}/{path}/{source}_release.{extension}"
+
     # BLAZEGRAPH SPECIFIC
     # url = f"{_graphEndpoint()}?uri={release_url}"  # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql?uri={release_url}"
     # get_dagster_logger().info(f'graph: insert "{source}" to {url} ')
@@ -201,6 +215,7 @@ def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_grap
     #     get_dagster_logger().info(f'graph: error')
     #     raise Exception(f' graph: insert failed: status:{r.status_code}')
 
+    release_url = _releaseUrl(source, path, extension)
     ### GENERIC LOAD FROM
     url = f"{graphendpoint}" # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql?uri={release_url}"
     get_dagster_logger().info(f'graph: insert "{source}" to {url} ')
@@ -685,9 +700,10 @@ def datadiscoverystudio_graph_reports(context) :
 
     graphendpoint = _graphEndpoint() # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql"
 
-    milled = False
-    summon = True
-    returned_value = generateGraphReportsRepo(source_name,  graphendpoint, reportList=reportTypes["repo_detailed"])
+
+    #returned_value = generateGraphReportsRepo(source_name,  graphendpoint, reportList=reportTypes["repo_detailed"])
+    s3FileUrl = _releaseUrl(source_name )
+    returned_value = generateGraphReportsRelease(source_name,s3FileUrl)
     r = str('returned value:{}'.format(returned_value))
     #report = json.dumps(returned_value, indent=2) # value already json.dumps
     report = returned_value
@@ -738,7 +754,13 @@ def datadiscoverystudio_summarize(context) :
 
     try:
 
-        summarydf = get_summary4repoSubset(endpoint, source_name)
+       # summarydf = get_summary4repoSubset(endpoint, source_name)
+        rg = ReleaseGraph()
+        rg.read_release(_pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT),
+                        bucket,
+                        source_name,
+                        options=MINIO_OPTIONS)
+        summarydf = rg.summarize()
         nt, g = summaryDF2ttl(summarydf, source_name)  # let's try the new generator
         summaryttl = g.serialize(format='longturtle')
         # Lets always write out file to s3, and insert as a separate process
@@ -791,10 +813,11 @@ def harvest_datadiscoverystudio():
 # defingin nothing dependencies
     # https://docs.dagster.io/concepts/ops-jobs-graphs/graphs#defining-nothing-dependencies
 
-    report_ms3 = datadiscoverystudio_missingreport_s3(start=harvest)
+    report_bucketurl = datadiscoverystudio_bucket_urls(start=harvest)
+    report_ms3 = datadiscoverystudio_missingreport_s3(start=report_bucketurl)
     report_idstat = datadiscoverystudio_identifier_stats(start=report_ms3)
     # for some reason, this causes a msg parameter missing
-    report_bucketurl = datadiscoverystudio_bucket_urls(start=report_idstat)
+
 
     #report1 = missingreport_s3(harvest, source="datadiscoverystudio")
     load_release = datadiscoverystudio_naburelease(start=harvest)
@@ -804,11 +827,14 @@ def harvest_datadiscoverystudio():
     load_prov = datadiscoverystudio_nabuprov(start=load_prune)
     load_org = datadiscoverystudio_nabuorg(start=load_prov)
 
-    summarize = datadiscoverystudio_summarize(start=load_uploadrelease)
-    upload_summarize = datadiscoverystudio_upload_summarize(start=summarize)
+    if(GLEANERIO_SUMMARIZE_GRAPH):
+        summarize = datadiscoverystudio_summarize(start=load_uploadrelease)
+        upload_summarize = datadiscoverystudio_upload_summarize(start=summarize)
+
+
 
 # run after load
-    report_msgraph = datadiscoverystudio_missingreport_graph(start=summarize)
+    report_msgraph = datadiscoverystudio_missingreport_graph(start=load_prov)
     report_graph = datadiscoverystudio_graph_reports(start=report_msgraph)
 
 

--- a/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_designsafe.py
+++ b/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_designsafe.py
@@ -12,10 +12,12 @@ from docker.types import RestartPolicy, ServiceMode
 from ec.gleanerio.gleaner import getGleaner, getSitemapSourcesFromGleaner, endpointUpdateNamespace
 import json
 
+from ec.graph.release_graph import ReleaseGraph
 from minio import Minio
 from minio.error import S3Error
 from datetime import datetime
-from ec.reporting.report import missingReport, generateGraphReportsRepo, reportTypes, generateIdentifierRepo
+from ec.reporting.report import missingReport, generateGraphReportsRepo, reportTypes, generateIdentifierRepo, \
+    generateGraphReportsRelease
 from ec.datastore import s3
 from ec.summarize import summaryDF2ttl, get_summary4graph, get_summary4repoSubset
 from ec.graph.manageGraph import ManageBlazegraph as mg
@@ -81,6 +83,7 @@ GLEANERIO_GLEANER_DOCKER_CONFIG=str(os.environ.get('GLEANERIO_GLEANER_DOCKER_CON
 GLEANERIO_NABU_DOCKER_CONFIG=str(os.environ.get('GLEANERIO_NABU_DOCKER_CONFIG', 'nabu'))
 #GLEANERIO_SUMMARY_GRAPH_ENDPOINT = os.environ.get('GLEANERIO_SUMMARY_GRAPH_ENDPOINT')
 GLEANERIO_SUMMARY_GRAPH_NAMESPACE = os.environ.get('GLEANERIO_SUMMARY_GRAPH_NAMESPACE',f"{GLEANER_GRAPH_NAMESPACE}_summary" )
+GLEANERIO_SUMMARIZE_GRAPH=(os.getenv('GLEANERIO_SUMMARIZE_GRAPH', 'False').lower()  == 'true')
 
 SUMMARY_PATH = 'graphs/summary'
 RELEASE_PATH = 'graphs/latest'
@@ -174,17 +177,28 @@ def s3loader(data, name):
                       content_type="text/plain"
                          )
     get_dagster_logger().info(f"Log uploaded: {str(objPrefix)}")
-def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_graphEndpoint()):
-    # revision of EC utilities, will have a insertFromURL
-    #instance =  mg.ManageBlazegraph(os.environ.get('GLEANER_GRAPH_URL'),os.environ.get('GLEANER_GRAPH_NAMESPACE') )
-    proto = "http"
 
+def _releaseUrl( source, path=RELEASE_PATH, extension="nq"):
+    proto = "http"
     if GLEANER_MINIO_USE_SSL:
         proto = "https"
-    port = GLEANER_MINIO_PORT
     address = _pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT)
     bucket = GLEANER_MINIO_BUCKET
     release_url = f"{proto}://{address}/{bucket}/{path}/{source}_release.{extension}"
+    return release_url
+
+def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_graphEndpoint()):
+    # revision of EC utilities, will have a insertFromURL
+    #instance =  mg.ManageBlazegraph(os.environ.get('GLEANER_GRAPH_URL'),os.environ.get('GLEANER_GRAPH_NAMESPACE') )
+    # proto = "http"
+    #
+    # if GLEANER_MINIO_USE_SSL:
+    #     proto = "https"
+    # port = GLEANER_MINIO_PORT
+    # address = _pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT)
+    # bucket = GLEANER_MINIO_BUCKET
+    # release_url = f"{proto}://{address}/{bucket}/{path}/{source}_release.{extension}"
+
     # BLAZEGRAPH SPECIFIC
     # url = f"{_graphEndpoint()}?uri={release_url}"  # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql?uri={release_url}"
     # get_dagster_logger().info(f'graph: insert "{source}" to {url} ')
@@ -201,6 +215,7 @@ def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_grap
     #     get_dagster_logger().info(f'graph: error')
     #     raise Exception(f' graph: insert failed: status:{r.status_code}')
 
+    release_url = _releaseUrl(source, path, extension)
     ### GENERIC LOAD FROM
     url = f"{graphendpoint}" # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql?uri={release_url}"
     get_dagster_logger().info(f'graph: insert "{source}" to {url} ')
@@ -685,9 +700,10 @@ def designsafe_graph_reports(context) :
 
     graphendpoint = _graphEndpoint() # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql"
 
-    milled = False
-    summon = True
-    returned_value = generateGraphReportsRepo(source_name,  graphendpoint, reportList=reportTypes["repo_detailed"])
+
+    #returned_value = generateGraphReportsRepo(source_name,  graphendpoint, reportList=reportTypes["repo_detailed"])
+    s3FileUrl = _releaseUrl(source_name )
+    returned_value = generateGraphReportsRelease(source_name,s3FileUrl)
     r = str('returned value:{}'.format(returned_value))
     #report = json.dumps(returned_value, indent=2) # value already json.dumps
     report = returned_value
@@ -738,7 +754,13 @@ def designsafe_summarize(context) :
 
     try:
 
-        summarydf = get_summary4repoSubset(endpoint, source_name)
+       # summarydf = get_summary4repoSubset(endpoint, source_name)
+        rg = ReleaseGraph()
+        rg.read_release(_pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT),
+                        bucket,
+                        source_name,
+                        options=MINIO_OPTIONS)
+        summarydf = rg.summarize()
         nt, g = summaryDF2ttl(summarydf, source_name)  # let's try the new generator
         summaryttl = g.serialize(format='longturtle')
         # Lets always write out file to s3, and insert as a separate process
@@ -791,10 +813,11 @@ def harvest_designsafe():
 # defingin nothing dependencies
     # https://docs.dagster.io/concepts/ops-jobs-graphs/graphs#defining-nothing-dependencies
 
-    report_ms3 = designsafe_missingreport_s3(start=harvest)
+    report_bucketurl = designsafe_bucket_urls(start=harvest)
+    report_ms3 = designsafe_missingreport_s3(start=report_bucketurl)
     report_idstat = designsafe_identifier_stats(start=report_ms3)
     # for some reason, this causes a msg parameter missing
-    report_bucketurl = designsafe_bucket_urls(start=report_idstat)
+
 
     #report1 = missingreport_s3(harvest, source="designsafe")
     load_release = designsafe_naburelease(start=harvest)
@@ -804,11 +827,14 @@ def harvest_designsafe():
     load_prov = designsafe_nabuprov(start=load_prune)
     load_org = designsafe_nabuorg(start=load_prov)
 
-    summarize = designsafe_summarize(start=load_uploadrelease)
-    upload_summarize = designsafe_upload_summarize(start=summarize)
+    if(GLEANERIO_SUMMARIZE_GRAPH):
+        summarize = designsafe_summarize(start=load_uploadrelease)
+        upload_summarize = designsafe_upload_summarize(start=summarize)
+
+
 
 # run after load
-    report_msgraph = designsafe_missingreport_graph(start=summarize)
+    report_msgraph = designsafe_missingreport_graph(start=load_prov)
     report_graph = designsafe_graph_reports(start=report_msgraph)
 
 

--- a/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_earthchem.py
+++ b/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_earthchem.py
@@ -12,10 +12,12 @@ from docker.types import RestartPolicy, ServiceMode
 from ec.gleanerio.gleaner import getGleaner, getSitemapSourcesFromGleaner, endpointUpdateNamespace
 import json
 
+from ec.graph.release_graph import ReleaseGraph
 from minio import Minio
 from minio.error import S3Error
 from datetime import datetime
-from ec.reporting.report import missingReport, generateGraphReportsRepo, reportTypes, generateIdentifierRepo
+from ec.reporting.report import missingReport, generateGraphReportsRepo, reportTypes, generateIdentifierRepo, \
+    generateGraphReportsRelease
 from ec.datastore import s3
 from ec.summarize import summaryDF2ttl, get_summary4graph, get_summary4repoSubset
 from ec.graph.manageGraph import ManageBlazegraph as mg
@@ -81,6 +83,7 @@ GLEANERIO_GLEANER_DOCKER_CONFIG=str(os.environ.get('GLEANERIO_GLEANER_DOCKER_CON
 GLEANERIO_NABU_DOCKER_CONFIG=str(os.environ.get('GLEANERIO_NABU_DOCKER_CONFIG', 'nabu'))
 #GLEANERIO_SUMMARY_GRAPH_ENDPOINT = os.environ.get('GLEANERIO_SUMMARY_GRAPH_ENDPOINT')
 GLEANERIO_SUMMARY_GRAPH_NAMESPACE = os.environ.get('GLEANERIO_SUMMARY_GRAPH_NAMESPACE',f"{GLEANER_GRAPH_NAMESPACE}_summary" )
+GLEANERIO_SUMMARIZE_GRAPH=(os.getenv('GLEANERIO_SUMMARIZE_GRAPH', 'False').lower()  == 'true')
 
 SUMMARY_PATH = 'graphs/summary'
 RELEASE_PATH = 'graphs/latest'
@@ -174,17 +177,28 @@ def s3loader(data, name):
                       content_type="text/plain"
                          )
     get_dagster_logger().info(f"Log uploaded: {str(objPrefix)}")
-def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_graphEndpoint()):
-    # revision of EC utilities, will have a insertFromURL
-    #instance =  mg.ManageBlazegraph(os.environ.get('GLEANER_GRAPH_URL'),os.environ.get('GLEANER_GRAPH_NAMESPACE') )
-    proto = "http"
 
+def _releaseUrl( source, path=RELEASE_PATH, extension="nq"):
+    proto = "http"
     if GLEANER_MINIO_USE_SSL:
         proto = "https"
-    port = GLEANER_MINIO_PORT
     address = _pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT)
     bucket = GLEANER_MINIO_BUCKET
     release_url = f"{proto}://{address}/{bucket}/{path}/{source}_release.{extension}"
+    return release_url
+
+def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_graphEndpoint()):
+    # revision of EC utilities, will have a insertFromURL
+    #instance =  mg.ManageBlazegraph(os.environ.get('GLEANER_GRAPH_URL'),os.environ.get('GLEANER_GRAPH_NAMESPACE') )
+    # proto = "http"
+    #
+    # if GLEANER_MINIO_USE_SSL:
+    #     proto = "https"
+    # port = GLEANER_MINIO_PORT
+    # address = _pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT)
+    # bucket = GLEANER_MINIO_BUCKET
+    # release_url = f"{proto}://{address}/{bucket}/{path}/{source}_release.{extension}"
+
     # BLAZEGRAPH SPECIFIC
     # url = f"{_graphEndpoint()}?uri={release_url}"  # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql?uri={release_url}"
     # get_dagster_logger().info(f'graph: insert "{source}" to {url} ')
@@ -201,6 +215,7 @@ def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_grap
     #     get_dagster_logger().info(f'graph: error')
     #     raise Exception(f' graph: insert failed: status:{r.status_code}')
 
+    release_url = _releaseUrl(source, path, extension)
     ### GENERIC LOAD FROM
     url = f"{graphendpoint}" # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql?uri={release_url}"
     get_dagster_logger().info(f'graph: insert "{source}" to {url} ')
@@ -685,9 +700,10 @@ def earthchem_graph_reports(context) :
 
     graphendpoint = _graphEndpoint() # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql"
 
-    milled = False
-    summon = True
-    returned_value = generateGraphReportsRepo(source_name,  graphendpoint, reportList=reportTypes["repo_detailed"])
+
+    #returned_value = generateGraphReportsRepo(source_name,  graphendpoint, reportList=reportTypes["repo_detailed"])
+    s3FileUrl = _releaseUrl(source_name )
+    returned_value = generateGraphReportsRelease(source_name,s3FileUrl)
     r = str('returned value:{}'.format(returned_value))
     #report = json.dumps(returned_value, indent=2) # value already json.dumps
     report = returned_value
@@ -738,7 +754,13 @@ def earthchem_summarize(context) :
 
     try:
 
-        summarydf = get_summary4repoSubset(endpoint, source_name)
+       # summarydf = get_summary4repoSubset(endpoint, source_name)
+        rg = ReleaseGraph()
+        rg.read_release(_pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT),
+                        bucket,
+                        source_name,
+                        options=MINIO_OPTIONS)
+        summarydf = rg.summarize()
         nt, g = summaryDF2ttl(summarydf, source_name)  # let's try the new generator
         summaryttl = g.serialize(format='longturtle')
         # Lets always write out file to s3, and insert as a separate process
@@ -791,10 +813,11 @@ def harvest_earthchem():
 # defingin nothing dependencies
     # https://docs.dagster.io/concepts/ops-jobs-graphs/graphs#defining-nothing-dependencies
 
-    report_ms3 = earthchem_missingreport_s3(start=harvest)
+    report_bucketurl = earthchem_bucket_urls(start=harvest)
+    report_ms3 = earthchem_missingreport_s3(start=report_bucketurl)
     report_idstat = earthchem_identifier_stats(start=report_ms3)
     # for some reason, this causes a msg parameter missing
-    report_bucketurl = earthchem_bucket_urls(start=report_idstat)
+
 
     #report1 = missingreport_s3(harvest, source="earthchem")
     load_release = earthchem_naburelease(start=harvest)
@@ -804,11 +827,14 @@ def harvest_earthchem():
     load_prov = earthchem_nabuprov(start=load_prune)
     load_org = earthchem_nabuorg(start=load_prov)
 
-    summarize = earthchem_summarize(start=load_uploadrelease)
-    upload_summarize = earthchem_upload_summarize(start=summarize)
+    if(GLEANERIO_SUMMARIZE_GRAPH):
+        summarize = earthchem_summarize(start=load_uploadrelease)
+        upload_summarize = earthchem_upload_summarize(start=summarize)
+
+
 
 # run after load
-    report_msgraph = earthchem_missingreport_graph(start=summarize)
+    report_msgraph = earthchem_missingreport_graph(start=load_prov)
     report_graph = earthchem_graph_reports(start=report_msgraph)
 
 

--- a/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_ecrr_examples.py
+++ b/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_ecrr_examples.py
@@ -12,10 +12,12 @@ from docker.types import RestartPolicy, ServiceMode
 from ec.gleanerio.gleaner import getGleaner, getSitemapSourcesFromGleaner, endpointUpdateNamespace
 import json
 
+from ec.graph.release_graph import ReleaseGraph
 from minio import Minio
 from minio.error import S3Error
 from datetime import datetime
-from ec.reporting.report import missingReport, generateGraphReportsRepo, reportTypes, generateIdentifierRepo
+from ec.reporting.report import missingReport, generateGraphReportsRepo, reportTypes, generateIdentifierRepo, \
+    generateGraphReportsRelease
 from ec.datastore import s3
 from ec.summarize import summaryDF2ttl, get_summary4graph, get_summary4repoSubset
 from ec.graph.manageGraph import ManageBlazegraph as mg
@@ -81,6 +83,7 @@ GLEANERIO_GLEANER_DOCKER_CONFIG=str(os.environ.get('GLEANERIO_GLEANER_DOCKER_CON
 GLEANERIO_NABU_DOCKER_CONFIG=str(os.environ.get('GLEANERIO_NABU_DOCKER_CONFIG', 'nabu'))
 #GLEANERIO_SUMMARY_GRAPH_ENDPOINT = os.environ.get('GLEANERIO_SUMMARY_GRAPH_ENDPOINT')
 GLEANERIO_SUMMARY_GRAPH_NAMESPACE = os.environ.get('GLEANERIO_SUMMARY_GRAPH_NAMESPACE',f"{GLEANER_GRAPH_NAMESPACE}_summary" )
+GLEANERIO_SUMMARIZE_GRAPH=(os.getenv('GLEANERIO_SUMMARIZE_GRAPH', 'False').lower()  == 'true')
 
 SUMMARY_PATH = 'graphs/summary'
 RELEASE_PATH = 'graphs/latest'
@@ -174,17 +177,28 @@ def s3loader(data, name):
                       content_type="text/plain"
                          )
     get_dagster_logger().info(f"Log uploaded: {str(objPrefix)}")
-def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_graphEndpoint()):
-    # revision of EC utilities, will have a insertFromURL
-    #instance =  mg.ManageBlazegraph(os.environ.get('GLEANER_GRAPH_URL'),os.environ.get('GLEANER_GRAPH_NAMESPACE') )
-    proto = "http"
 
+def _releaseUrl( source, path=RELEASE_PATH, extension="nq"):
+    proto = "http"
     if GLEANER_MINIO_USE_SSL:
         proto = "https"
-    port = GLEANER_MINIO_PORT
     address = _pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT)
     bucket = GLEANER_MINIO_BUCKET
     release_url = f"{proto}://{address}/{bucket}/{path}/{source}_release.{extension}"
+    return release_url
+
+def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_graphEndpoint()):
+    # revision of EC utilities, will have a insertFromURL
+    #instance =  mg.ManageBlazegraph(os.environ.get('GLEANER_GRAPH_URL'),os.environ.get('GLEANER_GRAPH_NAMESPACE') )
+    # proto = "http"
+    #
+    # if GLEANER_MINIO_USE_SSL:
+    #     proto = "https"
+    # port = GLEANER_MINIO_PORT
+    # address = _pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT)
+    # bucket = GLEANER_MINIO_BUCKET
+    # release_url = f"{proto}://{address}/{bucket}/{path}/{source}_release.{extension}"
+
     # BLAZEGRAPH SPECIFIC
     # url = f"{_graphEndpoint()}?uri={release_url}"  # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql?uri={release_url}"
     # get_dagster_logger().info(f'graph: insert "{source}" to {url} ')
@@ -201,6 +215,7 @@ def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_grap
     #     get_dagster_logger().info(f'graph: error')
     #     raise Exception(f' graph: insert failed: status:{r.status_code}')
 
+    release_url = _releaseUrl(source, path, extension)
     ### GENERIC LOAD FROM
     url = f"{graphendpoint}" # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql?uri={release_url}"
     get_dagster_logger().info(f'graph: insert "{source}" to {url} ')
@@ -685,9 +700,10 @@ def ecrr_examples_graph_reports(context) :
 
     graphendpoint = _graphEndpoint() # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql"
 
-    milled = False
-    summon = True
-    returned_value = generateGraphReportsRepo(source_name,  graphendpoint, reportList=reportTypes["repo_detailed"])
+
+    #returned_value = generateGraphReportsRepo(source_name,  graphendpoint, reportList=reportTypes["repo_detailed"])
+    s3FileUrl = _releaseUrl(source_name )
+    returned_value = generateGraphReportsRelease(source_name,s3FileUrl)
     r = str('returned value:{}'.format(returned_value))
     #report = json.dumps(returned_value, indent=2) # value already json.dumps
     report = returned_value
@@ -738,7 +754,13 @@ def ecrr_examples_summarize(context) :
 
     try:
 
-        summarydf = get_summary4repoSubset(endpoint, source_name)
+       # summarydf = get_summary4repoSubset(endpoint, source_name)
+        rg = ReleaseGraph()
+        rg.read_release(_pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT),
+                        bucket,
+                        source_name,
+                        options=MINIO_OPTIONS)
+        summarydf = rg.summarize()
         nt, g = summaryDF2ttl(summarydf, source_name)  # let's try the new generator
         summaryttl = g.serialize(format='longturtle')
         # Lets always write out file to s3, and insert as a separate process
@@ -791,10 +813,11 @@ def harvest_ecrr_examples():
 # defingin nothing dependencies
     # https://docs.dagster.io/concepts/ops-jobs-graphs/graphs#defining-nothing-dependencies
 
-    report_ms3 = ecrr_examples_missingreport_s3(start=harvest)
+    report_bucketurl = ecrr_examples_bucket_urls(start=harvest)
+    report_ms3 = ecrr_examples_missingreport_s3(start=report_bucketurl)
     report_idstat = ecrr_examples_identifier_stats(start=report_ms3)
     # for some reason, this causes a msg parameter missing
-    report_bucketurl = ecrr_examples_bucket_urls(start=report_idstat)
+
 
     #report1 = missingreport_s3(harvest, source="ecrr_examples")
     load_release = ecrr_examples_naburelease(start=harvest)
@@ -804,11 +827,14 @@ def harvest_ecrr_examples():
     load_prov = ecrr_examples_nabuprov(start=load_prune)
     load_org = ecrr_examples_nabuorg(start=load_prov)
 
-    summarize = ecrr_examples_summarize(start=load_uploadrelease)
-    upload_summarize = ecrr_examples_upload_summarize(start=summarize)
+    if(GLEANERIO_SUMMARIZE_GRAPH):
+        summarize = ecrr_examples_summarize(start=load_uploadrelease)
+        upload_summarize = ecrr_examples_upload_summarize(start=summarize)
+
+
 
 # run after load
-    report_msgraph = ecrr_examples_missingreport_graph(start=summarize)
+    report_msgraph = ecrr_examples_missingreport_graph(start=load_prov)
     report_graph = ecrr_examples_graph_reports(start=report_msgraph)
 
 

--- a/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_edi.py
+++ b/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_edi.py
@@ -12,10 +12,12 @@ from docker.types import RestartPolicy, ServiceMode
 from ec.gleanerio.gleaner import getGleaner, getSitemapSourcesFromGleaner, endpointUpdateNamespace
 import json
 
+from ec.graph.release_graph import ReleaseGraph
 from minio import Minio
 from minio.error import S3Error
 from datetime import datetime
-from ec.reporting.report import missingReport, generateGraphReportsRepo, reportTypes, generateIdentifierRepo
+from ec.reporting.report import missingReport, generateGraphReportsRepo, reportTypes, generateIdentifierRepo, \
+    generateGraphReportsRelease
 from ec.datastore import s3
 from ec.summarize import summaryDF2ttl, get_summary4graph, get_summary4repoSubset
 from ec.graph.manageGraph import ManageBlazegraph as mg
@@ -81,6 +83,7 @@ GLEANERIO_GLEANER_DOCKER_CONFIG=str(os.environ.get('GLEANERIO_GLEANER_DOCKER_CON
 GLEANERIO_NABU_DOCKER_CONFIG=str(os.environ.get('GLEANERIO_NABU_DOCKER_CONFIG', 'nabu'))
 #GLEANERIO_SUMMARY_GRAPH_ENDPOINT = os.environ.get('GLEANERIO_SUMMARY_GRAPH_ENDPOINT')
 GLEANERIO_SUMMARY_GRAPH_NAMESPACE = os.environ.get('GLEANERIO_SUMMARY_GRAPH_NAMESPACE',f"{GLEANER_GRAPH_NAMESPACE}_summary" )
+GLEANERIO_SUMMARIZE_GRAPH=(os.getenv('GLEANERIO_SUMMARIZE_GRAPH', 'False').lower()  == 'true')
 
 SUMMARY_PATH = 'graphs/summary'
 RELEASE_PATH = 'graphs/latest'
@@ -174,17 +177,28 @@ def s3loader(data, name):
                       content_type="text/plain"
                          )
     get_dagster_logger().info(f"Log uploaded: {str(objPrefix)}")
-def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_graphEndpoint()):
-    # revision of EC utilities, will have a insertFromURL
-    #instance =  mg.ManageBlazegraph(os.environ.get('GLEANER_GRAPH_URL'),os.environ.get('GLEANER_GRAPH_NAMESPACE') )
-    proto = "http"
 
+def _releaseUrl( source, path=RELEASE_PATH, extension="nq"):
+    proto = "http"
     if GLEANER_MINIO_USE_SSL:
         proto = "https"
-    port = GLEANER_MINIO_PORT
     address = _pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT)
     bucket = GLEANER_MINIO_BUCKET
     release_url = f"{proto}://{address}/{bucket}/{path}/{source}_release.{extension}"
+    return release_url
+
+def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_graphEndpoint()):
+    # revision of EC utilities, will have a insertFromURL
+    #instance =  mg.ManageBlazegraph(os.environ.get('GLEANER_GRAPH_URL'),os.environ.get('GLEANER_GRAPH_NAMESPACE') )
+    # proto = "http"
+    #
+    # if GLEANER_MINIO_USE_SSL:
+    #     proto = "https"
+    # port = GLEANER_MINIO_PORT
+    # address = _pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT)
+    # bucket = GLEANER_MINIO_BUCKET
+    # release_url = f"{proto}://{address}/{bucket}/{path}/{source}_release.{extension}"
+
     # BLAZEGRAPH SPECIFIC
     # url = f"{_graphEndpoint()}?uri={release_url}"  # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql?uri={release_url}"
     # get_dagster_logger().info(f'graph: insert "{source}" to {url} ')
@@ -201,6 +215,7 @@ def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_grap
     #     get_dagster_logger().info(f'graph: error')
     #     raise Exception(f' graph: insert failed: status:{r.status_code}')
 
+    release_url = _releaseUrl(source, path, extension)
     ### GENERIC LOAD FROM
     url = f"{graphendpoint}" # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql?uri={release_url}"
     get_dagster_logger().info(f'graph: insert "{source}" to {url} ')
@@ -685,9 +700,10 @@ def edi_graph_reports(context) :
 
     graphendpoint = _graphEndpoint() # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql"
 
-    milled = False
-    summon = True
-    returned_value = generateGraphReportsRepo(source_name,  graphendpoint, reportList=reportTypes["repo_detailed"])
+
+    #returned_value = generateGraphReportsRepo(source_name,  graphendpoint, reportList=reportTypes["repo_detailed"])
+    s3FileUrl = _releaseUrl(source_name )
+    returned_value = generateGraphReportsRelease(source_name,s3FileUrl)
     r = str('returned value:{}'.format(returned_value))
     #report = json.dumps(returned_value, indent=2) # value already json.dumps
     report = returned_value
@@ -738,7 +754,13 @@ def edi_summarize(context) :
 
     try:
 
-        summarydf = get_summary4repoSubset(endpoint, source_name)
+       # summarydf = get_summary4repoSubset(endpoint, source_name)
+        rg = ReleaseGraph()
+        rg.read_release(_pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT),
+                        bucket,
+                        source_name,
+                        options=MINIO_OPTIONS)
+        summarydf = rg.summarize()
         nt, g = summaryDF2ttl(summarydf, source_name)  # let's try the new generator
         summaryttl = g.serialize(format='longturtle')
         # Lets always write out file to s3, and insert as a separate process
@@ -791,10 +813,11 @@ def harvest_edi():
 # defingin nothing dependencies
     # https://docs.dagster.io/concepts/ops-jobs-graphs/graphs#defining-nothing-dependencies
 
-    report_ms3 = edi_missingreport_s3(start=harvest)
+    report_bucketurl = edi_bucket_urls(start=harvest)
+    report_ms3 = edi_missingreport_s3(start=report_bucketurl)
     report_idstat = edi_identifier_stats(start=report_ms3)
     # for some reason, this causes a msg parameter missing
-    report_bucketurl = edi_bucket_urls(start=report_idstat)
+
 
     #report1 = missingreport_s3(harvest, source="edi")
     load_release = edi_naburelease(start=harvest)
@@ -804,11 +827,14 @@ def harvest_edi():
     load_prov = edi_nabuprov(start=load_prune)
     load_org = edi_nabuorg(start=load_prov)
 
-    summarize = edi_summarize(start=load_uploadrelease)
-    upload_summarize = edi_upload_summarize(start=summarize)
+    if(GLEANERIO_SUMMARIZE_GRAPH):
+        summarize = edi_summarize(start=load_uploadrelease)
+        upload_summarize = edi_upload_summarize(start=summarize)
+
+
 
 # run after load
-    report_msgraph = edi_missingreport_graph(start=summarize)
+    report_msgraph = edi_missingreport_graph(start=load_prov)
     report_graph = edi_graph_reports(start=report_msgraph)
 
 

--- a/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_geocodes_demo_datasets.py
+++ b/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_geocodes_demo_datasets.py
@@ -12,10 +12,12 @@ from docker.types import RestartPolicy, ServiceMode
 from ec.gleanerio.gleaner import getGleaner, getSitemapSourcesFromGleaner, endpointUpdateNamespace
 import json
 
+from ec.graph.release_graph import ReleaseGraph
 from minio import Minio
 from minio.error import S3Error
 from datetime import datetime
-from ec.reporting.report import missingReport, generateGraphReportsRepo, reportTypes, generateIdentifierRepo
+from ec.reporting.report import missingReport, generateGraphReportsRepo, reportTypes, generateIdentifierRepo, \
+    generateGraphReportsRelease
 from ec.datastore import s3
 from ec.summarize import summaryDF2ttl, get_summary4graph, get_summary4repoSubset
 from ec.graph.manageGraph import ManageBlazegraph as mg
@@ -81,6 +83,7 @@ GLEANERIO_GLEANER_DOCKER_CONFIG=str(os.environ.get('GLEANERIO_GLEANER_DOCKER_CON
 GLEANERIO_NABU_DOCKER_CONFIG=str(os.environ.get('GLEANERIO_NABU_DOCKER_CONFIG', 'nabu'))
 #GLEANERIO_SUMMARY_GRAPH_ENDPOINT = os.environ.get('GLEANERIO_SUMMARY_GRAPH_ENDPOINT')
 GLEANERIO_SUMMARY_GRAPH_NAMESPACE = os.environ.get('GLEANERIO_SUMMARY_GRAPH_NAMESPACE',f"{GLEANER_GRAPH_NAMESPACE}_summary" )
+GLEANERIO_SUMMARIZE_GRAPH=(os.getenv('GLEANERIO_SUMMARIZE_GRAPH', 'False').lower()  == 'true')
 
 SUMMARY_PATH = 'graphs/summary'
 RELEASE_PATH = 'graphs/latest'
@@ -174,17 +177,28 @@ def s3loader(data, name):
                       content_type="text/plain"
                          )
     get_dagster_logger().info(f"Log uploaded: {str(objPrefix)}")
-def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_graphEndpoint()):
-    # revision of EC utilities, will have a insertFromURL
-    #instance =  mg.ManageBlazegraph(os.environ.get('GLEANER_GRAPH_URL'),os.environ.get('GLEANER_GRAPH_NAMESPACE') )
-    proto = "http"
 
+def _releaseUrl( source, path=RELEASE_PATH, extension="nq"):
+    proto = "http"
     if GLEANER_MINIO_USE_SSL:
         proto = "https"
-    port = GLEANER_MINIO_PORT
     address = _pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT)
     bucket = GLEANER_MINIO_BUCKET
     release_url = f"{proto}://{address}/{bucket}/{path}/{source}_release.{extension}"
+    return release_url
+
+def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_graphEndpoint()):
+    # revision of EC utilities, will have a insertFromURL
+    #instance =  mg.ManageBlazegraph(os.environ.get('GLEANER_GRAPH_URL'),os.environ.get('GLEANER_GRAPH_NAMESPACE') )
+    # proto = "http"
+    #
+    # if GLEANER_MINIO_USE_SSL:
+    #     proto = "https"
+    # port = GLEANER_MINIO_PORT
+    # address = _pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT)
+    # bucket = GLEANER_MINIO_BUCKET
+    # release_url = f"{proto}://{address}/{bucket}/{path}/{source}_release.{extension}"
+
     # BLAZEGRAPH SPECIFIC
     # url = f"{_graphEndpoint()}?uri={release_url}"  # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql?uri={release_url}"
     # get_dagster_logger().info(f'graph: insert "{source}" to {url} ')
@@ -201,6 +215,7 @@ def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_grap
     #     get_dagster_logger().info(f'graph: error')
     #     raise Exception(f' graph: insert failed: status:{r.status_code}')
 
+    release_url = _releaseUrl(source, path, extension)
     ### GENERIC LOAD FROM
     url = f"{graphendpoint}" # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql?uri={release_url}"
     get_dagster_logger().info(f'graph: insert "{source}" to {url} ')
@@ -685,9 +700,10 @@ def geocodes_demo_datasets_graph_reports(context) :
 
     graphendpoint = _graphEndpoint() # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql"
 
-    milled = False
-    summon = True
-    returned_value = generateGraphReportsRepo(source_name,  graphendpoint, reportList=reportTypes["repo_detailed"])
+
+    #returned_value = generateGraphReportsRepo(source_name,  graphendpoint, reportList=reportTypes["repo_detailed"])
+    s3FileUrl = _releaseUrl(source_name )
+    returned_value = generateGraphReportsRelease(source_name,s3FileUrl)
     r = str('returned value:{}'.format(returned_value))
     #report = json.dumps(returned_value, indent=2) # value already json.dumps
     report = returned_value
@@ -738,7 +754,13 @@ def geocodes_demo_datasets_summarize(context) :
 
     try:
 
-        summarydf = get_summary4repoSubset(endpoint, source_name)
+       # summarydf = get_summary4repoSubset(endpoint, source_name)
+        rg = ReleaseGraph()
+        rg.read_release(_pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT),
+                        bucket,
+                        source_name,
+                        options=MINIO_OPTIONS)
+        summarydf = rg.summarize()
         nt, g = summaryDF2ttl(summarydf, source_name)  # let's try the new generator
         summaryttl = g.serialize(format='longturtle')
         # Lets always write out file to s3, and insert as a separate process
@@ -791,10 +813,11 @@ def harvest_geocodes_demo_datasets():
 # defingin nothing dependencies
     # https://docs.dagster.io/concepts/ops-jobs-graphs/graphs#defining-nothing-dependencies
 
-    report_ms3 = geocodes_demo_datasets_missingreport_s3(start=harvest)
+    report_bucketurl = geocodes_demo_datasets_bucket_urls(start=harvest)
+    report_ms3 = geocodes_demo_datasets_missingreport_s3(start=report_bucketurl)
     report_idstat = geocodes_demo_datasets_identifier_stats(start=report_ms3)
     # for some reason, this causes a msg parameter missing
-    report_bucketurl = geocodes_demo_datasets_bucket_urls(start=report_idstat)
+
 
     #report1 = missingreport_s3(harvest, source="geocodes_demo_datasets")
     load_release = geocodes_demo_datasets_naburelease(start=harvest)
@@ -804,11 +827,14 @@ def harvest_geocodes_demo_datasets():
     load_prov = geocodes_demo_datasets_nabuprov(start=load_prune)
     load_org = geocodes_demo_datasets_nabuorg(start=load_prov)
 
-    summarize = geocodes_demo_datasets_summarize(start=load_uploadrelease)
-    upload_summarize = geocodes_demo_datasets_upload_summarize(start=summarize)
+    if(GLEANERIO_SUMMARIZE_GRAPH):
+        summarize = geocodes_demo_datasets_summarize(start=load_uploadrelease)
+        upload_summarize = geocodes_demo_datasets_upload_summarize(start=summarize)
+
+
 
 # run after load
-    report_msgraph = geocodes_demo_datasets_missingreport_graph(start=summarize)
+    report_msgraph = geocodes_demo_datasets_missingreport_graph(start=load_prov)
     report_graph = geocodes_demo_datasets_graph_reports(start=report_msgraph)
 
 

--- a/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_geocodes_examples.py
+++ b/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_geocodes_examples.py
@@ -12,10 +12,12 @@ from docker.types import RestartPolicy, ServiceMode
 from ec.gleanerio.gleaner import getGleaner, getSitemapSourcesFromGleaner, endpointUpdateNamespace
 import json
 
+from ec.graph.release_graph import ReleaseGraph
 from minio import Minio
 from minio.error import S3Error
 from datetime import datetime
-from ec.reporting.report import missingReport, generateGraphReportsRepo, reportTypes, generateIdentifierRepo
+from ec.reporting.report import missingReport, generateGraphReportsRepo, reportTypes, generateIdentifierRepo, \
+    generateGraphReportsRelease
 from ec.datastore import s3
 from ec.summarize import summaryDF2ttl, get_summary4graph, get_summary4repoSubset
 from ec.graph.manageGraph import ManageBlazegraph as mg
@@ -81,6 +83,7 @@ GLEANERIO_GLEANER_DOCKER_CONFIG=str(os.environ.get('GLEANERIO_GLEANER_DOCKER_CON
 GLEANERIO_NABU_DOCKER_CONFIG=str(os.environ.get('GLEANERIO_NABU_DOCKER_CONFIG', 'nabu'))
 #GLEANERIO_SUMMARY_GRAPH_ENDPOINT = os.environ.get('GLEANERIO_SUMMARY_GRAPH_ENDPOINT')
 GLEANERIO_SUMMARY_GRAPH_NAMESPACE = os.environ.get('GLEANERIO_SUMMARY_GRAPH_NAMESPACE',f"{GLEANER_GRAPH_NAMESPACE}_summary" )
+GLEANERIO_SUMMARIZE_GRAPH=(os.getenv('GLEANERIO_SUMMARIZE_GRAPH', 'False').lower()  == 'true')
 
 SUMMARY_PATH = 'graphs/summary'
 RELEASE_PATH = 'graphs/latest'
@@ -174,17 +177,28 @@ def s3loader(data, name):
                       content_type="text/plain"
                          )
     get_dagster_logger().info(f"Log uploaded: {str(objPrefix)}")
-def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_graphEndpoint()):
-    # revision of EC utilities, will have a insertFromURL
-    #instance =  mg.ManageBlazegraph(os.environ.get('GLEANER_GRAPH_URL'),os.environ.get('GLEANER_GRAPH_NAMESPACE') )
-    proto = "http"
 
+def _releaseUrl( source, path=RELEASE_PATH, extension="nq"):
+    proto = "http"
     if GLEANER_MINIO_USE_SSL:
         proto = "https"
-    port = GLEANER_MINIO_PORT
     address = _pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT)
     bucket = GLEANER_MINIO_BUCKET
     release_url = f"{proto}://{address}/{bucket}/{path}/{source}_release.{extension}"
+    return release_url
+
+def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_graphEndpoint()):
+    # revision of EC utilities, will have a insertFromURL
+    #instance =  mg.ManageBlazegraph(os.environ.get('GLEANER_GRAPH_URL'),os.environ.get('GLEANER_GRAPH_NAMESPACE') )
+    # proto = "http"
+    #
+    # if GLEANER_MINIO_USE_SSL:
+    #     proto = "https"
+    # port = GLEANER_MINIO_PORT
+    # address = _pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT)
+    # bucket = GLEANER_MINIO_BUCKET
+    # release_url = f"{proto}://{address}/{bucket}/{path}/{source}_release.{extension}"
+
     # BLAZEGRAPH SPECIFIC
     # url = f"{_graphEndpoint()}?uri={release_url}"  # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql?uri={release_url}"
     # get_dagster_logger().info(f'graph: insert "{source}" to {url} ')
@@ -201,6 +215,7 @@ def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_grap
     #     get_dagster_logger().info(f'graph: error')
     #     raise Exception(f' graph: insert failed: status:{r.status_code}')
 
+    release_url = _releaseUrl(source, path, extension)
     ### GENERIC LOAD FROM
     url = f"{graphendpoint}" # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql?uri={release_url}"
     get_dagster_logger().info(f'graph: insert "{source}" to {url} ')
@@ -685,9 +700,10 @@ def geocodes_examples_graph_reports(context) :
 
     graphendpoint = _graphEndpoint() # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql"
 
-    milled = False
-    summon = True
-    returned_value = generateGraphReportsRepo(source_name,  graphendpoint, reportList=reportTypes["repo_detailed"])
+
+    #returned_value = generateGraphReportsRepo(source_name,  graphendpoint, reportList=reportTypes["repo_detailed"])
+    s3FileUrl = _releaseUrl(source_name )
+    returned_value = generateGraphReportsRelease(source_name,s3FileUrl)
     r = str('returned value:{}'.format(returned_value))
     #report = json.dumps(returned_value, indent=2) # value already json.dumps
     report = returned_value
@@ -738,7 +754,13 @@ def geocodes_examples_summarize(context) :
 
     try:
 
-        summarydf = get_summary4repoSubset(endpoint, source_name)
+       # summarydf = get_summary4repoSubset(endpoint, source_name)
+        rg = ReleaseGraph()
+        rg.read_release(_pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT),
+                        bucket,
+                        source_name,
+                        options=MINIO_OPTIONS)
+        summarydf = rg.summarize()
         nt, g = summaryDF2ttl(summarydf, source_name)  # let's try the new generator
         summaryttl = g.serialize(format='longturtle')
         # Lets always write out file to s3, and insert as a separate process
@@ -791,10 +813,11 @@ def harvest_geocodes_examples():
 # defingin nothing dependencies
     # https://docs.dagster.io/concepts/ops-jobs-graphs/graphs#defining-nothing-dependencies
 
-    report_ms3 = geocodes_examples_missingreport_s3(start=harvest)
+    report_bucketurl = geocodes_examples_bucket_urls(start=harvest)
+    report_ms3 = geocodes_examples_missingreport_s3(start=report_bucketurl)
     report_idstat = geocodes_examples_identifier_stats(start=report_ms3)
     # for some reason, this causes a msg parameter missing
-    report_bucketurl = geocodes_examples_bucket_urls(start=report_idstat)
+
 
     #report1 = missingreport_s3(harvest, source="geocodes_examples")
     load_release = geocodes_examples_naburelease(start=harvest)
@@ -804,11 +827,14 @@ def harvest_geocodes_examples():
     load_prov = geocodes_examples_nabuprov(start=load_prune)
     load_org = geocodes_examples_nabuorg(start=load_prov)
 
-    summarize = geocodes_examples_summarize(start=load_uploadrelease)
-    upload_summarize = geocodes_examples_upload_summarize(start=summarize)
+    if(GLEANERIO_SUMMARIZE_GRAPH):
+        summarize = geocodes_examples_summarize(start=load_uploadrelease)
+        upload_summarize = geocodes_examples_upload_summarize(start=summarize)
+
+
 
 # run after load
-    report_msgraph = geocodes_examples_missingreport_graph(start=summarize)
+    report_msgraph = geocodes_examples_missingreport_graph(start=load_prov)
     report_graph = geocodes_examples_graph_reports(start=report_msgraph)
 
 

--- a/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_hydroshare.py
+++ b/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_hydroshare.py
@@ -12,10 +12,12 @@ from docker.types import RestartPolicy, ServiceMode
 from ec.gleanerio.gleaner import getGleaner, getSitemapSourcesFromGleaner, endpointUpdateNamespace
 import json
 
+from ec.graph.release_graph import ReleaseGraph
 from minio import Minio
 from minio.error import S3Error
 from datetime import datetime
-from ec.reporting.report import missingReport, generateGraphReportsRepo, reportTypes, generateIdentifierRepo
+from ec.reporting.report import missingReport, generateGraphReportsRepo, reportTypes, generateIdentifierRepo, \
+    generateGraphReportsRelease
 from ec.datastore import s3
 from ec.summarize import summaryDF2ttl, get_summary4graph, get_summary4repoSubset
 from ec.graph.manageGraph import ManageBlazegraph as mg
@@ -81,6 +83,7 @@ GLEANERIO_GLEANER_DOCKER_CONFIG=str(os.environ.get('GLEANERIO_GLEANER_DOCKER_CON
 GLEANERIO_NABU_DOCKER_CONFIG=str(os.environ.get('GLEANERIO_NABU_DOCKER_CONFIG', 'nabu'))
 #GLEANERIO_SUMMARY_GRAPH_ENDPOINT = os.environ.get('GLEANERIO_SUMMARY_GRAPH_ENDPOINT')
 GLEANERIO_SUMMARY_GRAPH_NAMESPACE = os.environ.get('GLEANERIO_SUMMARY_GRAPH_NAMESPACE',f"{GLEANER_GRAPH_NAMESPACE}_summary" )
+GLEANERIO_SUMMARIZE_GRAPH=(os.getenv('GLEANERIO_SUMMARIZE_GRAPH', 'False').lower()  == 'true')
 
 SUMMARY_PATH = 'graphs/summary'
 RELEASE_PATH = 'graphs/latest'
@@ -174,17 +177,28 @@ def s3loader(data, name):
                       content_type="text/plain"
                          )
     get_dagster_logger().info(f"Log uploaded: {str(objPrefix)}")
-def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_graphEndpoint()):
-    # revision of EC utilities, will have a insertFromURL
-    #instance =  mg.ManageBlazegraph(os.environ.get('GLEANER_GRAPH_URL'),os.environ.get('GLEANER_GRAPH_NAMESPACE') )
-    proto = "http"
 
+def _releaseUrl( source, path=RELEASE_PATH, extension="nq"):
+    proto = "http"
     if GLEANER_MINIO_USE_SSL:
         proto = "https"
-    port = GLEANER_MINIO_PORT
     address = _pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT)
     bucket = GLEANER_MINIO_BUCKET
     release_url = f"{proto}://{address}/{bucket}/{path}/{source}_release.{extension}"
+    return release_url
+
+def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_graphEndpoint()):
+    # revision of EC utilities, will have a insertFromURL
+    #instance =  mg.ManageBlazegraph(os.environ.get('GLEANER_GRAPH_URL'),os.environ.get('GLEANER_GRAPH_NAMESPACE') )
+    # proto = "http"
+    #
+    # if GLEANER_MINIO_USE_SSL:
+    #     proto = "https"
+    # port = GLEANER_MINIO_PORT
+    # address = _pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT)
+    # bucket = GLEANER_MINIO_BUCKET
+    # release_url = f"{proto}://{address}/{bucket}/{path}/{source}_release.{extension}"
+
     # BLAZEGRAPH SPECIFIC
     # url = f"{_graphEndpoint()}?uri={release_url}"  # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql?uri={release_url}"
     # get_dagster_logger().info(f'graph: insert "{source}" to {url} ')
@@ -201,6 +215,7 @@ def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_grap
     #     get_dagster_logger().info(f'graph: error')
     #     raise Exception(f' graph: insert failed: status:{r.status_code}')
 
+    release_url = _releaseUrl(source, path, extension)
     ### GENERIC LOAD FROM
     url = f"{graphendpoint}" # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql?uri={release_url}"
     get_dagster_logger().info(f'graph: insert "{source}" to {url} ')
@@ -685,9 +700,10 @@ def hydroshare_graph_reports(context) :
 
     graphendpoint = _graphEndpoint() # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql"
 
-    milled = False
-    summon = True
-    returned_value = generateGraphReportsRepo(source_name,  graphendpoint, reportList=reportTypes["repo_detailed"])
+
+    #returned_value = generateGraphReportsRepo(source_name,  graphendpoint, reportList=reportTypes["repo_detailed"])
+    s3FileUrl = _releaseUrl(source_name )
+    returned_value = generateGraphReportsRelease(source_name,s3FileUrl)
     r = str('returned value:{}'.format(returned_value))
     #report = json.dumps(returned_value, indent=2) # value already json.dumps
     report = returned_value
@@ -738,7 +754,13 @@ def hydroshare_summarize(context) :
 
     try:
 
-        summarydf = get_summary4repoSubset(endpoint, source_name)
+       # summarydf = get_summary4repoSubset(endpoint, source_name)
+        rg = ReleaseGraph()
+        rg.read_release(_pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT),
+                        bucket,
+                        source_name,
+                        options=MINIO_OPTIONS)
+        summarydf = rg.summarize()
         nt, g = summaryDF2ttl(summarydf, source_name)  # let's try the new generator
         summaryttl = g.serialize(format='longturtle')
         # Lets always write out file to s3, and insert as a separate process
@@ -791,10 +813,11 @@ def harvest_hydroshare():
 # defingin nothing dependencies
     # https://docs.dagster.io/concepts/ops-jobs-graphs/graphs#defining-nothing-dependencies
 
-    report_ms3 = hydroshare_missingreport_s3(start=harvest)
+    report_bucketurl = hydroshare_bucket_urls(start=harvest)
+    report_ms3 = hydroshare_missingreport_s3(start=report_bucketurl)
     report_idstat = hydroshare_identifier_stats(start=report_ms3)
     # for some reason, this causes a msg parameter missing
-    report_bucketurl = hydroshare_bucket_urls(start=report_idstat)
+
 
     #report1 = missingreport_s3(harvest, source="hydroshare")
     load_release = hydroshare_naburelease(start=harvest)
@@ -804,11 +827,14 @@ def harvest_hydroshare():
     load_prov = hydroshare_nabuprov(start=load_prune)
     load_org = hydroshare_nabuorg(start=load_prov)
 
-    summarize = hydroshare_summarize(start=load_uploadrelease)
-    upload_summarize = hydroshare_upload_summarize(start=summarize)
+    if(GLEANERIO_SUMMARIZE_GRAPH):
+        summarize = hydroshare_summarize(start=load_uploadrelease)
+        upload_summarize = hydroshare_upload_summarize(start=summarize)
+
+
 
 # run after load
-    report_msgraph = hydroshare_missingreport_graph(start=summarize)
+    report_msgraph = hydroshare_missingreport_graph(start=load_prov)
     report_graph = hydroshare_graph_reports(start=report_msgraph)
 
 

--- a/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_iedadata.py
+++ b/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_iedadata.py
@@ -12,10 +12,12 @@ from docker.types import RestartPolicy, ServiceMode
 from ec.gleanerio.gleaner import getGleaner, getSitemapSourcesFromGleaner, endpointUpdateNamespace
 import json
 
+from ec.graph.release_graph import ReleaseGraph
 from minio import Minio
 from minio.error import S3Error
 from datetime import datetime
-from ec.reporting.report import missingReport, generateGraphReportsRepo, reportTypes, generateIdentifierRepo
+from ec.reporting.report import missingReport, generateGraphReportsRepo, reportTypes, generateIdentifierRepo, \
+    generateGraphReportsRelease
 from ec.datastore import s3
 from ec.summarize import summaryDF2ttl, get_summary4graph, get_summary4repoSubset
 from ec.graph.manageGraph import ManageBlazegraph as mg
@@ -81,6 +83,7 @@ GLEANERIO_GLEANER_DOCKER_CONFIG=str(os.environ.get('GLEANERIO_GLEANER_DOCKER_CON
 GLEANERIO_NABU_DOCKER_CONFIG=str(os.environ.get('GLEANERIO_NABU_DOCKER_CONFIG', 'nabu'))
 #GLEANERIO_SUMMARY_GRAPH_ENDPOINT = os.environ.get('GLEANERIO_SUMMARY_GRAPH_ENDPOINT')
 GLEANERIO_SUMMARY_GRAPH_NAMESPACE = os.environ.get('GLEANERIO_SUMMARY_GRAPH_NAMESPACE',f"{GLEANER_GRAPH_NAMESPACE}_summary" )
+GLEANERIO_SUMMARIZE_GRAPH=(os.getenv('GLEANERIO_SUMMARIZE_GRAPH', 'False').lower()  == 'true')
 
 SUMMARY_PATH = 'graphs/summary'
 RELEASE_PATH = 'graphs/latest'
@@ -174,17 +177,28 @@ def s3loader(data, name):
                       content_type="text/plain"
                          )
     get_dagster_logger().info(f"Log uploaded: {str(objPrefix)}")
-def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_graphEndpoint()):
-    # revision of EC utilities, will have a insertFromURL
-    #instance =  mg.ManageBlazegraph(os.environ.get('GLEANER_GRAPH_URL'),os.environ.get('GLEANER_GRAPH_NAMESPACE') )
-    proto = "http"
 
+def _releaseUrl( source, path=RELEASE_PATH, extension="nq"):
+    proto = "http"
     if GLEANER_MINIO_USE_SSL:
         proto = "https"
-    port = GLEANER_MINIO_PORT
     address = _pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT)
     bucket = GLEANER_MINIO_BUCKET
     release_url = f"{proto}://{address}/{bucket}/{path}/{source}_release.{extension}"
+    return release_url
+
+def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_graphEndpoint()):
+    # revision of EC utilities, will have a insertFromURL
+    #instance =  mg.ManageBlazegraph(os.environ.get('GLEANER_GRAPH_URL'),os.environ.get('GLEANER_GRAPH_NAMESPACE') )
+    # proto = "http"
+    #
+    # if GLEANER_MINIO_USE_SSL:
+    #     proto = "https"
+    # port = GLEANER_MINIO_PORT
+    # address = _pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT)
+    # bucket = GLEANER_MINIO_BUCKET
+    # release_url = f"{proto}://{address}/{bucket}/{path}/{source}_release.{extension}"
+
     # BLAZEGRAPH SPECIFIC
     # url = f"{_graphEndpoint()}?uri={release_url}"  # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql?uri={release_url}"
     # get_dagster_logger().info(f'graph: insert "{source}" to {url} ')
@@ -201,6 +215,7 @@ def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_grap
     #     get_dagster_logger().info(f'graph: error')
     #     raise Exception(f' graph: insert failed: status:{r.status_code}')
 
+    release_url = _releaseUrl(source, path, extension)
     ### GENERIC LOAD FROM
     url = f"{graphendpoint}" # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql?uri={release_url}"
     get_dagster_logger().info(f'graph: insert "{source}" to {url} ')
@@ -685,9 +700,10 @@ def iedadata_graph_reports(context) :
 
     graphendpoint = _graphEndpoint() # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql"
 
-    milled = False
-    summon = True
-    returned_value = generateGraphReportsRepo(source_name,  graphendpoint, reportList=reportTypes["repo_detailed"])
+
+    #returned_value = generateGraphReportsRepo(source_name,  graphendpoint, reportList=reportTypes["repo_detailed"])
+    s3FileUrl = _releaseUrl(source_name )
+    returned_value = generateGraphReportsRelease(source_name,s3FileUrl)
     r = str('returned value:{}'.format(returned_value))
     #report = json.dumps(returned_value, indent=2) # value already json.dumps
     report = returned_value
@@ -738,7 +754,13 @@ def iedadata_summarize(context) :
 
     try:
 
-        summarydf = get_summary4repoSubset(endpoint, source_name)
+       # summarydf = get_summary4repoSubset(endpoint, source_name)
+        rg = ReleaseGraph()
+        rg.read_release(_pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT),
+                        bucket,
+                        source_name,
+                        options=MINIO_OPTIONS)
+        summarydf = rg.summarize()
         nt, g = summaryDF2ttl(summarydf, source_name)  # let's try the new generator
         summaryttl = g.serialize(format='longturtle')
         # Lets always write out file to s3, and insert as a separate process
@@ -791,10 +813,11 @@ def harvest_iedadata():
 # defingin nothing dependencies
     # https://docs.dagster.io/concepts/ops-jobs-graphs/graphs#defining-nothing-dependencies
 
-    report_ms3 = iedadata_missingreport_s3(start=harvest)
+    report_bucketurl = iedadata_bucket_urls(start=harvest)
+    report_ms3 = iedadata_missingreport_s3(start=report_bucketurl)
     report_idstat = iedadata_identifier_stats(start=report_ms3)
     # for some reason, this causes a msg parameter missing
-    report_bucketurl = iedadata_bucket_urls(start=report_idstat)
+
 
     #report1 = missingreport_s3(harvest, source="iedadata")
     load_release = iedadata_naburelease(start=harvest)
@@ -804,11 +827,14 @@ def harvest_iedadata():
     load_prov = iedadata_nabuprov(start=load_prune)
     load_org = iedadata_nabuorg(start=load_prov)
 
-    summarize = iedadata_summarize(start=load_uploadrelease)
-    upload_summarize = iedadata_upload_summarize(start=summarize)
+    if(GLEANERIO_SUMMARIZE_GRAPH):
+        summarize = iedadata_summarize(start=load_uploadrelease)
+        upload_summarize = iedadata_upload_summarize(start=summarize)
+
+
 
 # run after load
-    report_msgraph = iedadata_missingreport_graph(start=summarize)
+    report_msgraph = iedadata_missingreport_graph(start=load_prov)
     report_graph = iedadata_graph_reports(start=report_msgraph)
 
 

--- a/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_iris.py
+++ b/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_iris.py
@@ -12,10 +12,12 @@ from docker.types import RestartPolicy, ServiceMode
 from ec.gleanerio.gleaner import getGleaner, getSitemapSourcesFromGleaner, endpointUpdateNamespace
 import json
 
+from ec.graph.release_graph import ReleaseGraph
 from minio import Minio
 from minio.error import S3Error
 from datetime import datetime
-from ec.reporting.report import missingReport, generateGraphReportsRepo, reportTypes, generateIdentifierRepo
+from ec.reporting.report import missingReport, generateGraphReportsRepo, reportTypes, generateIdentifierRepo, \
+    generateGraphReportsRelease
 from ec.datastore import s3
 from ec.summarize import summaryDF2ttl, get_summary4graph, get_summary4repoSubset
 from ec.graph.manageGraph import ManageBlazegraph as mg
@@ -81,6 +83,7 @@ GLEANERIO_GLEANER_DOCKER_CONFIG=str(os.environ.get('GLEANERIO_GLEANER_DOCKER_CON
 GLEANERIO_NABU_DOCKER_CONFIG=str(os.environ.get('GLEANERIO_NABU_DOCKER_CONFIG', 'nabu'))
 #GLEANERIO_SUMMARY_GRAPH_ENDPOINT = os.environ.get('GLEANERIO_SUMMARY_GRAPH_ENDPOINT')
 GLEANERIO_SUMMARY_GRAPH_NAMESPACE = os.environ.get('GLEANERIO_SUMMARY_GRAPH_NAMESPACE',f"{GLEANER_GRAPH_NAMESPACE}_summary" )
+GLEANERIO_SUMMARIZE_GRAPH=(os.getenv('GLEANERIO_SUMMARIZE_GRAPH', 'False').lower()  == 'true')
 
 SUMMARY_PATH = 'graphs/summary'
 RELEASE_PATH = 'graphs/latest'
@@ -174,17 +177,28 @@ def s3loader(data, name):
                       content_type="text/plain"
                          )
     get_dagster_logger().info(f"Log uploaded: {str(objPrefix)}")
-def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_graphEndpoint()):
-    # revision of EC utilities, will have a insertFromURL
-    #instance =  mg.ManageBlazegraph(os.environ.get('GLEANER_GRAPH_URL'),os.environ.get('GLEANER_GRAPH_NAMESPACE') )
-    proto = "http"
 
+def _releaseUrl( source, path=RELEASE_PATH, extension="nq"):
+    proto = "http"
     if GLEANER_MINIO_USE_SSL:
         proto = "https"
-    port = GLEANER_MINIO_PORT
     address = _pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT)
     bucket = GLEANER_MINIO_BUCKET
     release_url = f"{proto}://{address}/{bucket}/{path}/{source}_release.{extension}"
+    return release_url
+
+def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_graphEndpoint()):
+    # revision of EC utilities, will have a insertFromURL
+    #instance =  mg.ManageBlazegraph(os.environ.get('GLEANER_GRAPH_URL'),os.environ.get('GLEANER_GRAPH_NAMESPACE') )
+    # proto = "http"
+    #
+    # if GLEANER_MINIO_USE_SSL:
+    #     proto = "https"
+    # port = GLEANER_MINIO_PORT
+    # address = _pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT)
+    # bucket = GLEANER_MINIO_BUCKET
+    # release_url = f"{proto}://{address}/{bucket}/{path}/{source}_release.{extension}"
+
     # BLAZEGRAPH SPECIFIC
     # url = f"{_graphEndpoint()}?uri={release_url}"  # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql?uri={release_url}"
     # get_dagster_logger().info(f'graph: insert "{source}" to {url} ')
@@ -201,6 +215,7 @@ def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_grap
     #     get_dagster_logger().info(f'graph: error')
     #     raise Exception(f' graph: insert failed: status:{r.status_code}')
 
+    release_url = _releaseUrl(source, path, extension)
     ### GENERIC LOAD FROM
     url = f"{graphendpoint}" # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql?uri={release_url}"
     get_dagster_logger().info(f'graph: insert "{source}" to {url} ')
@@ -685,9 +700,10 @@ def iris_graph_reports(context) :
 
     graphendpoint = _graphEndpoint() # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql"
 
-    milled = False
-    summon = True
-    returned_value = generateGraphReportsRepo(source_name,  graphendpoint, reportList=reportTypes["repo_detailed"])
+
+    #returned_value = generateGraphReportsRepo(source_name,  graphendpoint, reportList=reportTypes["repo_detailed"])
+    s3FileUrl = _releaseUrl(source_name )
+    returned_value = generateGraphReportsRelease(source_name,s3FileUrl)
     r = str('returned value:{}'.format(returned_value))
     #report = json.dumps(returned_value, indent=2) # value already json.dumps
     report = returned_value
@@ -738,7 +754,13 @@ def iris_summarize(context) :
 
     try:
 
-        summarydf = get_summary4repoSubset(endpoint, source_name)
+       # summarydf = get_summary4repoSubset(endpoint, source_name)
+        rg = ReleaseGraph()
+        rg.read_release(_pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT),
+                        bucket,
+                        source_name,
+                        options=MINIO_OPTIONS)
+        summarydf = rg.summarize()
         nt, g = summaryDF2ttl(summarydf, source_name)  # let's try the new generator
         summaryttl = g.serialize(format='longturtle')
         # Lets always write out file to s3, and insert as a separate process
@@ -791,10 +813,11 @@ def harvest_iris():
 # defingin nothing dependencies
     # https://docs.dagster.io/concepts/ops-jobs-graphs/graphs#defining-nothing-dependencies
 
-    report_ms3 = iris_missingreport_s3(start=harvest)
+    report_bucketurl = iris_bucket_urls(start=harvest)
+    report_ms3 = iris_missingreport_s3(start=report_bucketurl)
     report_idstat = iris_identifier_stats(start=report_ms3)
     # for some reason, this causes a msg parameter missing
-    report_bucketurl = iris_bucket_urls(start=report_idstat)
+
 
     #report1 = missingreport_s3(harvest, source="iris")
     load_release = iris_naburelease(start=harvest)
@@ -804,11 +827,14 @@ def harvest_iris():
     load_prov = iris_nabuprov(start=load_prune)
     load_org = iris_nabuorg(start=load_prov)
 
-    summarize = iris_summarize(start=load_uploadrelease)
-    upload_summarize = iris_upload_summarize(start=summarize)
+    if(GLEANERIO_SUMMARIZE_GRAPH):
+        summarize = iris_summarize(start=load_uploadrelease)
+        upload_summarize = iris_upload_summarize(start=summarize)
+
+
 
 # run after load
-    report_msgraph = iris_missingreport_graph(start=summarize)
+    report_msgraph = iris_missingreport_graph(start=load_prov)
     report_graph = iris_graph_reports(start=report_msgraph)
 
 

--- a/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_linkedearth.py
+++ b/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_linkedearth.py
@@ -12,10 +12,12 @@ from docker.types import RestartPolicy, ServiceMode
 from ec.gleanerio.gleaner import getGleaner, getSitemapSourcesFromGleaner, endpointUpdateNamespace
 import json
 
+from ec.graph.release_graph import ReleaseGraph
 from minio import Minio
 from minio.error import S3Error
 from datetime import datetime
-from ec.reporting.report import missingReport, generateGraphReportsRepo, reportTypes, generateIdentifierRepo
+from ec.reporting.report import missingReport, generateGraphReportsRepo, reportTypes, generateIdentifierRepo, \
+    generateGraphReportsRelease
 from ec.datastore import s3
 from ec.summarize import summaryDF2ttl, get_summary4graph, get_summary4repoSubset
 from ec.graph.manageGraph import ManageBlazegraph as mg
@@ -81,6 +83,7 @@ GLEANERIO_GLEANER_DOCKER_CONFIG=str(os.environ.get('GLEANERIO_GLEANER_DOCKER_CON
 GLEANERIO_NABU_DOCKER_CONFIG=str(os.environ.get('GLEANERIO_NABU_DOCKER_CONFIG', 'nabu'))
 #GLEANERIO_SUMMARY_GRAPH_ENDPOINT = os.environ.get('GLEANERIO_SUMMARY_GRAPH_ENDPOINT')
 GLEANERIO_SUMMARY_GRAPH_NAMESPACE = os.environ.get('GLEANERIO_SUMMARY_GRAPH_NAMESPACE',f"{GLEANER_GRAPH_NAMESPACE}_summary" )
+GLEANERIO_SUMMARIZE_GRAPH=(os.getenv('GLEANERIO_SUMMARIZE_GRAPH', 'False').lower()  == 'true')
 
 SUMMARY_PATH = 'graphs/summary'
 RELEASE_PATH = 'graphs/latest'
@@ -174,17 +177,28 @@ def s3loader(data, name):
                       content_type="text/plain"
                          )
     get_dagster_logger().info(f"Log uploaded: {str(objPrefix)}")
-def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_graphEndpoint()):
-    # revision of EC utilities, will have a insertFromURL
-    #instance =  mg.ManageBlazegraph(os.environ.get('GLEANER_GRAPH_URL'),os.environ.get('GLEANER_GRAPH_NAMESPACE') )
-    proto = "http"
 
+def _releaseUrl( source, path=RELEASE_PATH, extension="nq"):
+    proto = "http"
     if GLEANER_MINIO_USE_SSL:
         proto = "https"
-    port = GLEANER_MINIO_PORT
     address = _pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT)
     bucket = GLEANER_MINIO_BUCKET
     release_url = f"{proto}://{address}/{bucket}/{path}/{source}_release.{extension}"
+    return release_url
+
+def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_graphEndpoint()):
+    # revision of EC utilities, will have a insertFromURL
+    #instance =  mg.ManageBlazegraph(os.environ.get('GLEANER_GRAPH_URL'),os.environ.get('GLEANER_GRAPH_NAMESPACE') )
+    # proto = "http"
+    #
+    # if GLEANER_MINIO_USE_SSL:
+    #     proto = "https"
+    # port = GLEANER_MINIO_PORT
+    # address = _pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT)
+    # bucket = GLEANER_MINIO_BUCKET
+    # release_url = f"{proto}://{address}/{bucket}/{path}/{source}_release.{extension}"
+
     # BLAZEGRAPH SPECIFIC
     # url = f"{_graphEndpoint()}?uri={release_url}"  # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql?uri={release_url}"
     # get_dagster_logger().info(f'graph: insert "{source}" to {url} ')
@@ -201,6 +215,7 @@ def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_grap
     #     get_dagster_logger().info(f'graph: error')
     #     raise Exception(f' graph: insert failed: status:{r.status_code}')
 
+    release_url = _releaseUrl(source, path, extension)
     ### GENERIC LOAD FROM
     url = f"{graphendpoint}" # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql?uri={release_url}"
     get_dagster_logger().info(f'graph: insert "{source}" to {url} ')
@@ -685,9 +700,10 @@ def linkedearth_graph_reports(context) :
 
     graphendpoint = _graphEndpoint() # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql"
 
-    milled = False
-    summon = True
-    returned_value = generateGraphReportsRepo(source_name,  graphendpoint, reportList=reportTypes["repo_detailed"])
+
+    #returned_value = generateGraphReportsRepo(source_name,  graphendpoint, reportList=reportTypes["repo_detailed"])
+    s3FileUrl = _releaseUrl(source_name )
+    returned_value = generateGraphReportsRelease(source_name,s3FileUrl)
     r = str('returned value:{}'.format(returned_value))
     #report = json.dumps(returned_value, indent=2) # value already json.dumps
     report = returned_value
@@ -738,7 +754,13 @@ def linkedearth_summarize(context) :
 
     try:
 
-        summarydf = get_summary4repoSubset(endpoint, source_name)
+       # summarydf = get_summary4repoSubset(endpoint, source_name)
+        rg = ReleaseGraph()
+        rg.read_release(_pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT),
+                        bucket,
+                        source_name,
+                        options=MINIO_OPTIONS)
+        summarydf = rg.summarize()
         nt, g = summaryDF2ttl(summarydf, source_name)  # let's try the new generator
         summaryttl = g.serialize(format='longturtle')
         # Lets always write out file to s3, and insert as a separate process
@@ -791,10 +813,11 @@ def harvest_linkedearth():
 # defingin nothing dependencies
     # https://docs.dagster.io/concepts/ops-jobs-graphs/graphs#defining-nothing-dependencies
 
-    report_ms3 = linkedearth_missingreport_s3(start=harvest)
+    report_bucketurl = linkedearth_bucket_urls(start=harvest)
+    report_ms3 = linkedearth_missingreport_s3(start=report_bucketurl)
     report_idstat = linkedearth_identifier_stats(start=report_ms3)
     # for some reason, this causes a msg parameter missing
-    report_bucketurl = linkedearth_bucket_urls(start=report_idstat)
+
 
     #report1 = missingreport_s3(harvest, source="linkedearth")
     load_release = linkedearth_naburelease(start=harvest)
@@ -804,11 +827,14 @@ def harvest_linkedearth():
     load_prov = linkedearth_nabuprov(start=load_prune)
     load_org = linkedearth_nabuorg(start=load_prov)
 
-    summarize = linkedearth_summarize(start=load_uploadrelease)
-    upload_summarize = linkedearth_upload_summarize(start=summarize)
+    if(GLEANERIO_SUMMARIZE_GRAPH):
+        summarize = linkedearth_summarize(start=load_uploadrelease)
+        upload_summarize = linkedearth_upload_summarize(start=summarize)
+
+
 
 # run after load
-    report_msgraph = linkedearth_missingreport_graph(start=summarize)
+    report_msgraph = linkedearth_missingreport_graph(start=load_prov)
     report_graph = linkedearth_graph_reports(start=report_msgraph)
 
 

--- a/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_lipdverse.py
+++ b/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_lipdverse.py
@@ -12,10 +12,12 @@ from docker.types import RestartPolicy, ServiceMode
 from ec.gleanerio.gleaner import getGleaner, getSitemapSourcesFromGleaner, endpointUpdateNamespace
 import json
 
+from ec.graph.release_graph import ReleaseGraph
 from minio import Minio
 from minio.error import S3Error
 from datetime import datetime
-from ec.reporting.report import missingReport, generateGraphReportsRepo, reportTypes, generateIdentifierRepo
+from ec.reporting.report import missingReport, generateGraphReportsRepo, reportTypes, generateIdentifierRepo, \
+    generateGraphReportsRelease
 from ec.datastore import s3
 from ec.summarize import summaryDF2ttl, get_summary4graph, get_summary4repoSubset
 from ec.graph.manageGraph import ManageBlazegraph as mg
@@ -81,6 +83,7 @@ GLEANERIO_GLEANER_DOCKER_CONFIG=str(os.environ.get('GLEANERIO_GLEANER_DOCKER_CON
 GLEANERIO_NABU_DOCKER_CONFIG=str(os.environ.get('GLEANERIO_NABU_DOCKER_CONFIG', 'nabu'))
 #GLEANERIO_SUMMARY_GRAPH_ENDPOINT = os.environ.get('GLEANERIO_SUMMARY_GRAPH_ENDPOINT')
 GLEANERIO_SUMMARY_GRAPH_NAMESPACE = os.environ.get('GLEANERIO_SUMMARY_GRAPH_NAMESPACE',f"{GLEANER_GRAPH_NAMESPACE}_summary" )
+GLEANERIO_SUMMARIZE_GRAPH=(os.getenv('GLEANERIO_SUMMARIZE_GRAPH', 'False').lower()  == 'true')
 
 SUMMARY_PATH = 'graphs/summary'
 RELEASE_PATH = 'graphs/latest'
@@ -174,17 +177,28 @@ def s3loader(data, name):
                       content_type="text/plain"
                          )
     get_dagster_logger().info(f"Log uploaded: {str(objPrefix)}")
-def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_graphEndpoint()):
-    # revision of EC utilities, will have a insertFromURL
-    #instance =  mg.ManageBlazegraph(os.environ.get('GLEANER_GRAPH_URL'),os.environ.get('GLEANER_GRAPH_NAMESPACE') )
-    proto = "http"
 
+def _releaseUrl( source, path=RELEASE_PATH, extension="nq"):
+    proto = "http"
     if GLEANER_MINIO_USE_SSL:
         proto = "https"
-    port = GLEANER_MINIO_PORT
     address = _pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT)
     bucket = GLEANER_MINIO_BUCKET
     release_url = f"{proto}://{address}/{bucket}/{path}/{source}_release.{extension}"
+    return release_url
+
+def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_graphEndpoint()):
+    # revision of EC utilities, will have a insertFromURL
+    #instance =  mg.ManageBlazegraph(os.environ.get('GLEANER_GRAPH_URL'),os.environ.get('GLEANER_GRAPH_NAMESPACE') )
+    # proto = "http"
+    #
+    # if GLEANER_MINIO_USE_SSL:
+    #     proto = "https"
+    # port = GLEANER_MINIO_PORT
+    # address = _pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT)
+    # bucket = GLEANER_MINIO_BUCKET
+    # release_url = f"{proto}://{address}/{bucket}/{path}/{source}_release.{extension}"
+
     # BLAZEGRAPH SPECIFIC
     # url = f"{_graphEndpoint()}?uri={release_url}"  # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql?uri={release_url}"
     # get_dagster_logger().info(f'graph: insert "{source}" to {url} ')
@@ -201,6 +215,7 @@ def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_grap
     #     get_dagster_logger().info(f'graph: error')
     #     raise Exception(f' graph: insert failed: status:{r.status_code}')
 
+    release_url = _releaseUrl(source, path, extension)
     ### GENERIC LOAD FROM
     url = f"{graphendpoint}" # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql?uri={release_url}"
     get_dagster_logger().info(f'graph: insert "{source}" to {url} ')
@@ -685,9 +700,10 @@ def lipdverse_graph_reports(context) :
 
     graphendpoint = _graphEndpoint() # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql"
 
-    milled = False
-    summon = True
-    returned_value = generateGraphReportsRepo(source_name,  graphendpoint, reportList=reportTypes["repo_detailed"])
+
+    #returned_value = generateGraphReportsRepo(source_name,  graphendpoint, reportList=reportTypes["repo_detailed"])
+    s3FileUrl = _releaseUrl(source_name )
+    returned_value = generateGraphReportsRelease(source_name,s3FileUrl)
     r = str('returned value:{}'.format(returned_value))
     #report = json.dumps(returned_value, indent=2) # value already json.dumps
     report = returned_value
@@ -738,7 +754,13 @@ def lipdverse_summarize(context) :
 
     try:
 
-        summarydf = get_summary4repoSubset(endpoint, source_name)
+       # summarydf = get_summary4repoSubset(endpoint, source_name)
+        rg = ReleaseGraph()
+        rg.read_release(_pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT),
+                        bucket,
+                        source_name,
+                        options=MINIO_OPTIONS)
+        summarydf = rg.summarize()
         nt, g = summaryDF2ttl(summarydf, source_name)  # let's try the new generator
         summaryttl = g.serialize(format='longturtle')
         # Lets always write out file to s3, and insert as a separate process
@@ -791,10 +813,11 @@ def harvest_lipdverse():
 # defingin nothing dependencies
     # https://docs.dagster.io/concepts/ops-jobs-graphs/graphs#defining-nothing-dependencies
 
-    report_ms3 = lipdverse_missingreport_s3(start=harvest)
+    report_bucketurl = lipdverse_bucket_urls(start=harvest)
+    report_ms3 = lipdverse_missingreport_s3(start=report_bucketurl)
     report_idstat = lipdverse_identifier_stats(start=report_ms3)
     # for some reason, this causes a msg parameter missing
-    report_bucketurl = lipdverse_bucket_urls(start=report_idstat)
+
 
     #report1 = missingreport_s3(harvest, source="lipdverse")
     load_release = lipdverse_naburelease(start=harvest)
@@ -804,11 +827,14 @@ def harvest_lipdverse():
     load_prov = lipdverse_nabuprov(start=load_prune)
     load_org = lipdverse_nabuorg(start=load_prov)
 
-    summarize = lipdverse_summarize(start=load_uploadrelease)
-    upload_summarize = lipdverse_upload_summarize(start=summarize)
+    if(GLEANERIO_SUMMARIZE_GRAPH):
+        summarize = lipdverse_summarize(start=load_uploadrelease)
+        upload_summarize = lipdverse_upload_summarize(start=summarize)
+
+
 
 # run after load
-    report_msgraph = lipdverse_missingreport_graph(start=summarize)
+    report_msgraph = lipdverse_missingreport_graph(start=load_prov)
     report_graph = lipdverse_graph_reports(start=report_msgraph)
 
 

--- a/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_magic.py
+++ b/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_magic.py
@@ -12,10 +12,12 @@ from docker.types import RestartPolicy, ServiceMode
 from ec.gleanerio.gleaner import getGleaner, getSitemapSourcesFromGleaner, endpointUpdateNamespace
 import json
 
+from ec.graph.release_graph import ReleaseGraph
 from minio import Minio
 from minio.error import S3Error
 from datetime import datetime
-from ec.reporting.report import missingReport, generateGraphReportsRepo, reportTypes, generateIdentifierRepo
+from ec.reporting.report import missingReport, generateGraphReportsRepo, reportTypes, generateIdentifierRepo, \
+    generateGraphReportsRelease
 from ec.datastore import s3
 from ec.summarize import summaryDF2ttl, get_summary4graph, get_summary4repoSubset
 from ec.graph.manageGraph import ManageBlazegraph as mg
@@ -81,6 +83,7 @@ GLEANERIO_GLEANER_DOCKER_CONFIG=str(os.environ.get('GLEANERIO_GLEANER_DOCKER_CON
 GLEANERIO_NABU_DOCKER_CONFIG=str(os.environ.get('GLEANERIO_NABU_DOCKER_CONFIG', 'nabu'))
 #GLEANERIO_SUMMARY_GRAPH_ENDPOINT = os.environ.get('GLEANERIO_SUMMARY_GRAPH_ENDPOINT')
 GLEANERIO_SUMMARY_GRAPH_NAMESPACE = os.environ.get('GLEANERIO_SUMMARY_GRAPH_NAMESPACE',f"{GLEANER_GRAPH_NAMESPACE}_summary" )
+GLEANERIO_SUMMARIZE_GRAPH=(os.getenv('GLEANERIO_SUMMARIZE_GRAPH', 'False').lower()  == 'true')
 
 SUMMARY_PATH = 'graphs/summary'
 RELEASE_PATH = 'graphs/latest'
@@ -174,17 +177,28 @@ def s3loader(data, name):
                       content_type="text/plain"
                          )
     get_dagster_logger().info(f"Log uploaded: {str(objPrefix)}")
-def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_graphEndpoint()):
-    # revision of EC utilities, will have a insertFromURL
-    #instance =  mg.ManageBlazegraph(os.environ.get('GLEANER_GRAPH_URL'),os.environ.get('GLEANER_GRAPH_NAMESPACE') )
-    proto = "http"
 
+def _releaseUrl( source, path=RELEASE_PATH, extension="nq"):
+    proto = "http"
     if GLEANER_MINIO_USE_SSL:
         proto = "https"
-    port = GLEANER_MINIO_PORT
     address = _pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT)
     bucket = GLEANER_MINIO_BUCKET
     release_url = f"{proto}://{address}/{bucket}/{path}/{source}_release.{extension}"
+    return release_url
+
+def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_graphEndpoint()):
+    # revision of EC utilities, will have a insertFromURL
+    #instance =  mg.ManageBlazegraph(os.environ.get('GLEANER_GRAPH_URL'),os.environ.get('GLEANER_GRAPH_NAMESPACE') )
+    # proto = "http"
+    #
+    # if GLEANER_MINIO_USE_SSL:
+    #     proto = "https"
+    # port = GLEANER_MINIO_PORT
+    # address = _pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT)
+    # bucket = GLEANER_MINIO_BUCKET
+    # release_url = f"{proto}://{address}/{bucket}/{path}/{source}_release.{extension}"
+
     # BLAZEGRAPH SPECIFIC
     # url = f"{_graphEndpoint()}?uri={release_url}"  # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql?uri={release_url}"
     # get_dagster_logger().info(f'graph: insert "{source}" to {url} ')
@@ -201,6 +215,7 @@ def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_grap
     #     get_dagster_logger().info(f'graph: error')
     #     raise Exception(f' graph: insert failed: status:{r.status_code}')
 
+    release_url = _releaseUrl(source, path, extension)
     ### GENERIC LOAD FROM
     url = f"{graphendpoint}" # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql?uri={release_url}"
     get_dagster_logger().info(f'graph: insert "{source}" to {url} ')
@@ -685,9 +700,10 @@ def magic_graph_reports(context) :
 
     graphendpoint = _graphEndpoint() # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql"
 
-    milled = False
-    summon = True
-    returned_value = generateGraphReportsRepo(source_name,  graphendpoint, reportList=reportTypes["repo_detailed"])
+
+    #returned_value = generateGraphReportsRepo(source_name,  graphendpoint, reportList=reportTypes["repo_detailed"])
+    s3FileUrl = _releaseUrl(source_name )
+    returned_value = generateGraphReportsRelease(source_name,s3FileUrl)
     r = str('returned value:{}'.format(returned_value))
     #report = json.dumps(returned_value, indent=2) # value already json.dumps
     report = returned_value
@@ -738,7 +754,13 @@ def magic_summarize(context) :
 
     try:
 
-        summarydf = get_summary4repoSubset(endpoint, source_name)
+       # summarydf = get_summary4repoSubset(endpoint, source_name)
+        rg = ReleaseGraph()
+        rg.read_release(_pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT),
+                        bucket,
+                        source_name,
+                        options=MINIO_OPTIONS)
+        summarydf = rg.summarize()
         nt, g = summaryDF2ttl(summarydf, source_name)  # let's try the new generator
         summaryttl = g.serialize(format='longturtle')
         # Lets always write out file to s3, and insert as a separate process
@@ -791,10 +813,11 @@ def harvest_magic():
 # defingin nothing dependencies
     # https://docs.dagster.io/concepts/ops-jobs-graphs/graphs#defining-nothing-dependencies
 
-    report_ms3 = magic_missingreport_s3(start=harvest)
+    report_bucketurl = magic_bucket_urls(start=harvest)
+    report_ms3 = magic_missingreport_s3(start=report_bucketurl)
     report_idstat = magic_identifier_stats(start=report_ms3)
     # for some reason, this causes a msg parameter missing
-    report_bucketurl = magic_bucket_urls(start=report_idstat)
+
 
     #report1 = missingreport_s3(harvest, source="magic")
     load_release = magic_naburelease(start=harvest)
@@ -804,11 +827,14 @@ def harvest_magic():
     load_prov = magic_nabuprov(start=load_prune)
     load_org = magic_nabuorg(start=load_prov)
 
-    summarize = magic_summarize(start=load_uploadrelease)
-    upload_summarize = magic_upload_summarize(start=summarize)
+    if(GLEANERIO_SUMMARIZE_GRAPH):
+        summarize = magic_summarize(start=load_uploadrelease)
+        upload_summarize = magic_upload_summarize(start=summarize)
+
+
 
 # run after load
-    report_msgraph = magic_missingreport_graph(start=summarize)
+    report_msgraph = magic_missingreport_graph(start=load_prov)
     report_graph = magic_graph_reports(start=report_msgraph)
 
 

--- a/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_neon.py
+++ b/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_neon.py
@@ -12,10 +12,12 @@ from docker.types import RestartPolicy, ServiceMode
 from ec.gleanerio.gleaner import getGleaner, getSitemapSourcesFromGleaner, endpointUpdateNamespace
 import json
 
+from ec.graph.release_graph import ReleaseGraph
 from minio import Minio
 from minio.error import S3Error
 from datetime import datetime
-from ec.reporting.report import missingReport, generateGraphReportsRepo, reportTypes, generateIdentifierRepo
+from ec.reporting.report import missingReport, generateGraphReportsRepo, reportTypes, generateIdentifierRepo, \
+    generateGraphReportsRelease
 from ec.datastore import s3
 from ec.summarize import summaryDF2ttl, get_summary4graph, get_summary4repoSubset
 from ec.graph.manageGraph import ManageBlazegraph as mg
@@ -81,6 +83,7 @@ GLEANERIO_GLEANER_DOCKER_CONFIG=str(os.environ.get('GLEANERIO_GLEANER_DOCKER_CON
 GLEANERIO_NABU_DOCKER_CONFIG=str(os.environ.get('GLEANERIO_NABU_DOCKER_CONFIG', 'nabu'))
 #GLEANERIO_SUMMARY_GRAPH_ENDPOINT = os.environ.get('GLEANERIO_SUMMARY_GRAPH_ENDPOINT')
 GLEANERIO_SUMMARY_GRAPH_NAMESPACE = os.environ.get('GLEANERIO_SUMMARY_GRAPH_NAMESPACE',f"{GLEANER_GRAPH_NAMESPACE}_summary" )
+GLEANERIO_SUMMARIZE_GRAPH=(os.getenv('GLEANERIO_SUMMARIZE_GRAPH', 'False').lower()  == 'true')
 
 SUMMARY_PATH = 'graphs/summary'
 RELEASE_PATH = 'graphs/latest'
@@ -174,17 +177,28 @@ def s3loader(data, name):
                       content_type="text/plain"
                          )
     get_dagster_logger().info(f"Log uploaded: {str(objPrefix)}")
-def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_graphEndpoint()):
-    # revision of EC utilities, will have a insertFromURL
-    #instance =  mg.ManageBlazegraph(os.environ.get('GLEANER_GRAPH_URL'),os.environ.get('GLEANER_GRAPH_NAMESPACE') )
-    proto = "http"
 
+def _releaseUrl( source, path=RELEASE_PATH, extension="nq"):
+    proto = "http"
     if GLEANER_MINIO_USE_SSL:
         proto = "https"
-    port = GLEANER_MINIO_PORT
     address = _pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT)
     bucket = GLEANER_MINIO_BUCKET
     release_url = f"{proto}://{address}/{bucket}/{path}/{source}_release.{extension}"
+    return release_url
+
+def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_graphEndpoint()):
+    # revision of EC utilities, will have a insertFromURL
+    #instance =  mg.ManageBlazegraph(os.environ.get('GLEANER_GRAPH_URL'),os.environ.get('GLEANER_GRAPH_NAMESPACE') )
+    # proto = "http"
+    #
+    # if GLEANER_MINIO_USE_SSL:
+    #     proto = "https"
+    # port = GLEANER_MINIO_PORT
+    # address = _pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT)
+    # bucket = GLEANER_MINIO_BUCKET
+    # release_url = f"{proto}://{address}/{bucket}/{path}/{source}_release.{extension}"
+
     # BLAZEGRAPH SPECIFIC
     # url = f"{_graphEndpoint()}?uri={release_url}"  # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql?uri={release_url}"
     # get_dagster_logger().info(f'graph: insert "{source}" to {url} ')
@@ -201,6 +215,7 @@ def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_grap
     #     get_dagster_logger().info(f'graph: error')
     #     raise Exception(f' graph: insert failed: status:{r.status_code}')
 
+    release_url = _releaseUrl(source, path, extension)
     ### GENERIC LOAD FROM
     url = f"{graphendpoint}" # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql?uri={release_url}"
     get_dagster_logger().info(f'graph: insert "{source}" to {url} ')
@@ -685,9 +700,10 @@ def neon_graph_reports(context) :
 
     graphendpoint = _graphEndpoint() # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql"
 
-    milled = False
-    summon = True
-    returned_value = generateGraphReportsRepo(source_name,  graphendpoint, reportList=reportTypes["repo_detailed"])
+
+    #returned_value = generateGraphReportsRepo(source_name,  graphendpoint, reportList=reportTypes["repo_detailed"])
+    s3FileUrl = _releaseUrl(source_name )
+    returned_value = generateGraphReportsRelease(source_name,s3FileUrl)
     r = str('returned value:{}'.format(returned_value))
     #report = json.dumps(returned_value, indent=2) # value already json.dumps
     report = returned_value
@@ -738,7 +754,13 @@ def neon_summarize(context) :
 
     try:
 
-        summarydf = get_summary4repoSubset(endpoint, source_name)
+       # summarydf = get_summary4repoSubset(endpoint, source_name)
+        rg = ReleaseGraph()
+        rg.read_release(_pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT),
+                        bucket,
+                        source_name,
+                        options=MINIO_OPTIONS)
+        summarydf = rg.summarize()
         nt, g = summaryDF2ttl(summarydf, source_name)  # let's try the new generator
         summaryttl = g.serialize(format='longturtle')
         # Lets always write out file to s3, and insert as a separate process
@@ -791,10 +813,11 @@ def harvest_neon():
 # defingin nothing dependencies
     # https://docs.dagster.io/concepts/ops-jobs-graphs/graphs#defining-nothing-dependencies
 
-    report_ms3 = neon_missingreport_s3(start=harvest)
+    report_bucketurl = neon_bucket_urls(start=harvest)
+    report_ms3 = neon_missingreport_s3(start=report_bucketurl)
     report_idstat = neon_identifier_stats(start=report_ms3)
     # for some reason, this causes a msg parameter missing
-    report_bucketurl = neon_bucket_urls(start=report_idstat)
+
 
     #report1 = missingreport_s3(harvest, source="neon")
     load_release = neon_naburelease(start=harvest)
@@ -804,11 +827,14 @@ def harvest_neon():
     load_prov = neon_nabuprov(start=load_prune)
     load_org = neon_nabuorg(start=load_prov)
 
-    summarize = neon_summarize(start=load_uploadrelease)
-    upload_summarize = neon_upload_summarize(start=summarize)
+    if(GLEANERIO_SUMMARIZE_GRAPH):
+        summarize = neon_summarize(start=load_uploadrelease)
+        upload_summarize = neon_upload_summarize(start=summarize)
+
+
 
 # run after load
-    report_msgraph = neon_missingreport_graph(start=summarize)
+    report_msgraph = neon_missingreport_graph(start=load_prov)
     report_graph = neon_graph_reports(start=report_msgraph)
 
 

--- a/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_neotomadb.py
+++ b/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_neotomadb.py
@@ -12,10 +12,12 @@ from docker.types import RestartPolicy, ServiceMode
 from ec.gleanerio.gleaner import getGleaner, getSitemapSourcesFromGleaner, endpointUpdateNamespace
 import json
 
+from ec.graph.release_graph import ReleaseGraph
 from minio import Minio
 from minio.error import S3Error
 from datetime import datetime
-from ec.reporting.report import missingReport, generateGraphReportsRepo, reportTypes, generateIdentifierRepo
+from ec.reporting.report import missingReport, generateGraphReportsRepo, reportTypes, generateIdentifierRepo, \
+    generateGraphReportsRelease
 from ec.datastore import s3
 from ec.summarize import summaryDF2ttl, get_summary4graph, get_summary4repoSubset
 from ec.graph.manageGraph import ManageBlazegraph as mg
@@ -81,6 +83,7 @@ GLEANERIO_GLEANER_DOCKER_CONFIG=str(os.environ.get('GLEANERIO_GLEANER_DOCKER_CON
 GLEANERIO_NABU_DOCKER_CONFIG=str(os.environ.get('GLEANERIO_NABU_DOCKER_CONFIG', 'nabu'))
 #GLEANERIO_SUMMARY_GRAPH_ENDPOINT = os.environ.get('GLEANERIO_SUMMARY_GRAPH_ENDPOINT')
 GLEANERIO_SUMMARY_GRAPH_NAMESPACE = os.environ.get('GLEANERIO_SUMMARY_GRAPH_NAMESPACE',f"{GLEANER_GRAPH_NAMESPACE}_summary" )
+GLEANERIO_SUMMARIZE_GRAPH=(os.getenv('GLEANERIO_SUMMARIZE_GRAPH', 'False').lower()  == 'true')
 
 SUMMARY_PATH = 'graphs/summary'
 RELEASE_PATH = 'graphs/latest'
@@ -174,17 +177,28 @@ def s3loader(data, name):
                       content_type="text/plain"
                          )
     get_dagster_logger().info(f"Log uploaded: {str(objPrefix)}")
-def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_graphEndpoint()):
-    # revision of EC utilities, will have a insertFromURL
-    #instance =  mg.ManageBlazegraph(os.environ.get('GLEANER_GRAPH_URL'),os.environ.get('GLEANER_GRAPH_NAMESPACE') )
-    proto = "http"
 
+def _releaseUrl( source, path=RELEASE_PATH, extension="nq"):
+    proto = "http"
     if GLEANER_MINIO_USE_SSL:
         proto = "https"
-    port = GLEANER_MINIO_PORT
     address = _pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT)
     bucket = GLEANER_MINIO_BUCKET
     release_url = f"{proto}://{address}/{bucket}/{path}/{source}_release.{extension}"
+    return release_url
+
+def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_graphEndpoint()):
+    # revision of EC utilities, will have a insertFromURL
+    #instance =  mg.ManageBlazegraph(os.environ.get('GLEANER_GRAPH_URL'),os.environ.get('GLEANER_GRAPH_NAMESPACE') )
+    # proto = "http"
+    #
+    # if GLEANER_MINIO_USE_SSL:
+    #     proto = "https"
+    # port = GLEANER_MINIO_PORT
+    # address = _pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT)
+    # bucket = GLEANER_MINIO_BUCKET
+    # release_url = f"{proto}://{address}/{bucket}/{path}/{source}_release.{extension}"
+
     # BLAZEGRAPH SPECIFIC
     # url = f"{_graphEndpoint()}?uri={release_url}"  # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql?uri={release_url}"
     # get_dagster_logger().info(f'graph: insert "{source}" to {url} ')
@@ -201,6 +215,7 @@ def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_grap
     #     get_dagster_logger().info(f'graph: error')
     #     raise Exception(f' graph: insert failed: status:{r.status_code}')
 
+    release_url = _releaseUrl(source, path, extension)
     ### GENERIC LOAD FROM
     url = f"{graphendpoint}" # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql?uri={release_url}"
     get_dagster_logger().info(f'graph: insert "{source}" to {url} ')
@@ -685,9 +700,10 @@ def neotomadb_graph_reports(context) :
 
     graphendpoint = _graphEndpoint() # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql"
 
-    milled = False
-    summon = True
-    returned_value = generateGraphReportsRepo(source_name,  graphendpoint, reportList=reportTypes["repo_detailed"])
+
+    #returned_value = generateGraphReportsRepo(source_name,  graphendpoint, reportList=reportTypes["repo_detailed"])
+    s3FileUrl = _releaseUrl(source_name )
+    returned_value = generateGraphReportsRelease(source_name,s3FileUrl)
     r = str('returned value:{}'.format(returned_value))
     #report = json.dumps(returned_value, indent=2) # value already json.dumps
     report = returned_value
@@ -738,7 +754,13 @@ def neotomadb_summarize(context) :
 
     try:
 
-        summarydf = get_summary4repoSubset(endpoint, source_name)
+       # summarydf = get_summary4repoSubset(endpoint, source_name)
+        rg = ReleaseGraph()
+        rg.read_release(_pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT),
+                        bucket,
+                        source_name,
+                        options=MINIO_OPTIONS)
+        summarydf = rg.summarize()
         nt, g = summaryDF2ttl(summarydf, source_name)  # let's try the new generator
         summaryttl = g.serialize(format='longturtle')
         # Lets always write out file to s3, and insert as a separate process
@@ -791,10 +813,11 @@ def harvest_neotomadb():
 # defingin nothing dependencies
     # https://docs.dagster.io/concepts/ops-jobs-graphs/graphs#defining-nothing-dependencies
 
-    report_ms3 = neotomadb_missingreport_s3(start=harvest)
+    report_bucketurl = neotomadb_bucket_urls(start=harvest)
+    report_ms3 = neotomadb_missingreport_s3(start=report_bucketurl)
     report_idstat = neotomadb_identifier_stats(start=report_ms3)
     # for some reason, this causes a msg parameter missing
-    report_bucketurl = neotomadb_bucket_urls(start=report_idstat)
+
 
     #report1 = missingreport_s3(harvest, source="neotomadb")
     load_release = neotomadb_naburelease(start=harvest)
@@ -804,11 +827,14 @@ def harvest_neotomadb():
     load_prov = neotomadb_nabuprov(start=load_prune)
     load_org = neotomadb_nabuorg(start=load_prov)
 
-    summarize = neotomadb_summarize(start=load_uploadrelease)
-    upload_summarize = neotomadb_upload_summarize(start=summarize)
+    if(GLEANERIO_SUMMARIZE_GRAPH):
+        summarize = neotomadb_summarize(start=load_uploadrelease)
+        upload_summarize = neotomadb_upload_summarize(start=summarize)
+
+
 
 # run after load
-    report_msgraph = neotomadb_missingreport_graph(start=summarize)
+    report_msgraph = neotomadb_missingreport_graph(start=load_prov)
     report_graph = neotomadb_graph_reports(start=report_msgraph)
 
 

--- a/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_opencoredata.py
+++ b/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_opencoredata.py
@@ -12,10 +12,12 @@ from docker.types import RestartPolicy, ServiceMode
 from ec.gleanerio.gleaner import getGleaner, getSitemapSourcesFromGleaner, endpointUpdateNamespace
 import json
 
+from ec.graph.release_graph import ReleaseGraph
 from minio import Minio
 from minio.error import S3Error
 from datetime import datetime
-from ec.reporting.report import missingReport, generateGraphReportsRepo, reportTypes, generateIdentifierRepo
+from ec.reporting.report import missingReport, generateGraphReportsRepo, reportTypes, generateIdentifierRepo, \
+    generateGraphReportsRelease
 from ec.datastore import s3
 from ec.summarize import summaryDF2ttl, get_summary4graph, get_summary4repoSubset
 from ec.graph.manageGraph import ManageBlazegraph as mg
@@ -81,6 +83,7 @@ GLEANERIO_GLEANER_DOCKER_CONFIG=str(os.environ.get('GLEANERIO_GLEANER_DOCKER_CON
 GLEANERIO_NABU_DOCKER_CONFIG=str(os.environ.get('GLEANERIO_NABU_DOCKER_CONFIG', 'nabu'))
 #GLEANERIO_SUMMARY_GRAPH_ENDPOINT = os.environ.get('GLEANERIO_SUMMARY_GRAPH_ENDPOINT')
 GLEANERIO_SUMMARY_GRAPH_NAMESPACE = os.environ.get('GLEANERIO_SUMMARY_GRAPH_NAMESPACE',f"{GLEANER_GRAPH_NAMESPACE}_summary" )
+GLEANERIO_SUMMARIZE_GRAPH=(os.getenv('GLEANERIO_SUMMARIZE_GRAPH', 'False').lower()  == 'true')
 
 SUMMARY_PATH = 'graphs/summary'
 RELEASE_PATH = 'graphs/latest'
@@ -174,17 +177,28 @@ def s3loader(data, name):
                       content_type="text/plain"
                          )
     get_dagster_logger().info(f"Log uploaded: {str(objPrefix)}")
-def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_graphEndpoint()):
-    # revision of EC utilities, will have a insertFromURL
-    #instance =  mg.ManageBlazegraph(os.environ.get('GLEANER_GRAPH_URL'),os.environ.get('GLEANER_GRAPH_NAMESPACE') )
-    proto = "http"
 
+def _releaseUrl( source, path=RELEASE_PATH, extension="nq"):
+    proto = "http"
     if GLEANER_MINIO_USE_SSL:
         proto = "https"
-    port = GLEANER_MINIO_PORT
     address = _pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT)
     bucket = GLEANER_MINIO_BUCKET
     release_url = f"{proto}://{address}/{bucket}/{path}/{source}_release.{extension}"
+    return release_url
+
+def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_graphEndpoint()):
+    # revision of EC utilities, will have a insertFromURL
+    #instance =  mg.ManageBlazegraph(os.environ.get('GLEANER_GRAPH_URL'),os.environ.get('GLEANER_GRAPH_NAMESPACE') )
+    # proto = "http"
+    #
+    # if GLEANER_MINIO_USE_SSL:
+    #     proto = "https"
+    # port = GLEANER_MINIO_PORT
+    # address = _pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT)
+    # bucket = GLEANER_MINIO_BUCKET
+    # release_url = f"{proto}://{address}/{bucket}/{path}/{source}_release.{extension}"
+
     # BLAZEGRAPH SPECIFIC
     # url = f"{_graphEndpoint()}?uri={release_url}"  # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql?uri={release_url}"
     # get_dagster_logger().info(f'graph: insert "{source}" to {url} ')
@@ -201,6 +215,7 @@ def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_grap
     #     get_dagster_logger().info(f'graph: error')
     #     raise Exception(f' graph: insert failed: status:{r.status_code}')
 
+    release_url = _releaseUrl(source, path, extension)
     ### GENERIC LOAD FROM
     url = f"{graphendpoint}" # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql?uri={release_url}"
     get_dagster_logger().info(f'graph: insert "{source}" to {url} ')
@@ -685,9 +700,10 @@ def opencoredata_graph_reports(context) :
 
     graphendpoint = _graphEndpoint() # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql"
 
-    milled = False
-    summon = True
-    returned_value = generateGraphReportsRepo(source_name,  graphendpoint, reportList=reportTypes["repo_detailed"])
+
+    #returned_value = generateGraphReportsRepo(source_name,  graphendpoint, reportList=reportTypes["repo_detailed"])
+    s3FileUrl = _releaseUrl(source_name )
+    returned_value = generateGraphReportsRelease(source_name,s3FileUrl)
     r = str('returned value:{}'.format(returned_value))
     #report = json.dumps(returned_value, indent=2) # value already json.dumps
     report = returned_value
@@ -738,7 +754,13 @@ def opencoredata_summarize(context) :
 
     try:
 
-        summarydf = get_summary4repoSubset(endpoint, source_name)
+       # summarydf = get_summary4repoSubset(endpoint, source_name)
+        rg = ReleaseGraph()
+        rg.read_release(_pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT),
+                        bucket,
+                        source_name,
+                        options=MINIO_OPTIONS)
+        summarydf = rg.summarize()
         nt, g = summaryDF2ttl(summarydf, source_name)  # let's try the new generator
         summaryttl = g.serialize(format='longturtle')
         # Lets always write out file to s3, and insert as a separate process
@@ -791,10 +813,11 @@ def harvest_opencoredata():
 # defingin nothing dependencies
     # https://docs.dagster.io/concepts/ops-jobs-graphs/graphs#defining-nothing-dependencies
 
-    report_ms3 = opencoredata_missingreport_s3(start=harvest)
+    report_bucketurl = opencoredata_bucket_urls(start=harvest)
+    report_ms3 = opencoredata_missingreport_s3(start=report_bucketurl)
     report_idstat = opencoredata_identifier_stats(start=report_ms3)
     # for some reason, this causes a msg parameter missing
-    report_bucketurl = opencoredata_bucket_urls(start=report_idstat)
+
 
     #report1 = missingreport_s3(harvest, source="opencoredata")
     load_release = opencoredata_naburelease(start=harvest)
@@ -804,11 +827,14 @@ def harvest_opencoredata():
     load_prov = opencoredata_nabuprov(start=load_prune)
     load_org = opencoredata_nabuorg(start=load_prov)
 
-    summarize = opencoredata_summarize(start=load_uploadrelease)
-    upload_summarize = opencoredata_upload_summarize(start=summarize)
+    if(GLEANERIO_SUMMARIZE_GRAPH):
+        summarize = opencoredata_summarize(start=load_uploadrelease)
+        upload_summarize = opencoredata_upload_summarize(start=summarize)
+
+
 
 # run after load
-    report_msgraph = opencoredata_missingreport_graph(start=summarize)
+    report_msgraph = opencoredata_missingreport_graph(start=load_prov)
     report_graph = opencoredata_graph_reports(start=report_msgraph)
 
 

--- a/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_opentopography.py
+++ b/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_opentopography.py
@@ -12,10 +12,12 @@ from docker.types import RestartPolicy, ServiceMode
 from ec.gleanerio.gleaner import getGleaner, getSitemapSourcesFromGleaner, endpointUpdateNamespace
 import json
 
+from ec.graph.release_graph import ReleaseGraph
 from minio import Minio
 from minio.error import S3Error
 from datetime import datetime
-from ec.reporting.report import missingReport, generateGraphReportsRepo, reportTypes, generateIdentifierRepo
+from ec.reporting.report import missingReport, generateGraphReportsRepo, reportTypes, generateIdentifierRepo, \
+    generateGraphReportsRelease
 from ec.datastore import s3
 from ec.summarize import summaryDF2ttl, get_summary4graph, get_summary4repoSubset
 from ec.graph.manageGraph import ManageBlazegraph as mg
@@ -81,6 +83,7 @@ GLEANERIO_GLEANER_DOCKER_CONFIG=str(os.environ.get('GLEANERIO_GLEANER_DOCKER_CON
 GLEANERIO_NABU_DOCKER_CONFIG=str(os.environ.get('GLEANERIO_NABU_DOCKER_CONFIG', 'nabu'))
 #GLEANERIO_SUMMARY_GRAPH_ENDPOINT = os.environ.get('GLEANERIO_SUMMARY_GRAPH_ENDPOINT')
 GLEANERIO_SUMMARY_GRAPH_NAMESPACE = os.environ.get('GLEANERIO_SUMMARY_GRAPH_NAMESPACE',f"{GLEANER_GRAPH_NAMESPACE}_summary" )
+GLEANERIO_SUMMARIZE_GRAPH=(os.getenv('GLEANERIO_SUMMARIZE_GRAPH', 'False').lower()  == 'true')
 
 SUMMARY_PATH = 'graphs/summary'
 RELEASE_PATH = 'graphs/latest'
@@ -174,17 +177,28 @@ def s3loader(data, name):
                       content_type="text/plain"
                          )
     get_dagster_logger().info(f"Log uploaded: {str(objPrefix)}")
-def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_graphEndpoint()):
-    # revision of EC utilities, will have a insertFromURL
-    #instance =  mg.ManageBlazegraph(os.environ.get('GLEANER_GRAPH_URL'),os.environ.get('GLEANER_GRAPH_NAMESPACE') )
-    proto = "http"
 
+def _releaseUrl( source, path=RELEASE_PATH, extension="nq"):
+    proto = "http"
     if GLEANER_MINIO_USE_SSL:
         proto = "https"
-    port = GLEANER_MINIO_PORT
     address = _pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT)
     bucket = GLEANER_MINIO_BUCKET
     release_url = f"{proto}://{address}/{bucket}/{path}/{source}_release.{extension}"
+    return release_url
+
+def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_graphEndpoint()):
+    # revision of EC utilities, will have a insertFromURL
+    #instance =  mg.ManageBlazegraph(os.environ.get('GLEANER_GRAPH_URL'),os.environ.get('GLEANER_GRAPH_NAMESPACE') )
+    # proto = "http"
+    #
+    # if GLEANER_MINIO_USE_SSL:
+    #     proto = "https"
+    # port = GLEANER_MINIO_PORT
+    # address = _pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT)
+    # bucket = GLEANER_MINIO_BUCKET
+    # release_url = f"{proto}://{address}/{bucket}/{path}/{source}_release.{extension}"
+
     # BLAZEGRAPH SPECIFIC
     # url = f"{_graphEndpoint()}?uri={release_url}"  # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql?uri={release_url}"
     # get_dagster_logger().info(f'graph: insert "{source}" to {url} ')
@@ -201,6 +215,7 @@ def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_grap
     #     get_dagster_logger().info(f'graph: error')
     #     raise Exception(f' graph: insert failed: status:{r.status_code}')
 
+    release_url = _releaseUrl(source, path, extension)
     ### GENERIC LOAD FROM
     url = f"{graphendpoint}" # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql?uri={release_url}"
     get_dagster_logger().info(f'graph: insert "{source}" to {url} ')
@@ -685,9 +700,10 @@ def opentopography_graph_reports(context) :
 
     graphendpoint = _graphEndpoint() # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql"
 
-    milled = False
-    summon = True
-    returned_value = generateGraphReportsRepo(source_name,  graphendpoint, reportList=reportTypes["repo_detailed"])
+
+    #returned_value = generateGraphReportsRepo(source_name,  graphendpoint, reportList=reportTypes["repo_detailed"])
+    s3FileUrl = _releaseUrl(source_name )
+    returned_value = generateGraphReportsRelease(source_name,s3FileUrl)
     r = str('returned value:{}'.format(returned_value))
     #report = json.dumps(returned_value, indent=2) # value already json.dumps
     report = returned_value
@@ -738,7 +754,13 @@ def opentopography_summarize(context) :
 
     try:
 
-        summarydf = get_summary4repoSubset(endpoint, source_name)
+       # summarydf = get_summary4repoSubset(endpoint, source_name)
+        rg = ReleaseGraph()
+        rg.read_release(_pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT),
+                        bucket,
+                        source_name,
+                        options=MINIO_OPTIONS)
+        summarydf = rg.summarize()
         nt, g = summaryDF2ttl(summarydf, source_name)  # let's try the new generator
         summaryttl = g.serialize(format='longturtle')
         # Lets always write out file to s3, and insert as a separate process
@@ -791,10 +813,11 @@ def harvest_opentopography():
 # defingin nothing dependencies
     # https://docs.dagster.io/concepts/ops-jobs-graphs/graphs#defining-nothing-dependencies
 
-    report_ms3 = opentopography_missingreport_s3(start=harvest)
+    report_bucketurl = opentopography_bucket_urls(start=harvest)
+    report_ms3 = opentopography_missingreport_s3(start=report_bucketurl)
     report_idstat = opentopography_identifier_stats(start=report_ms3)
     # for some reason, this causes a msg parameter missing
-    report_bucketurl = opentopography_bucket_urls(start=report_idstat)
+
 
     #report1 = missingreport_s3(harvest, source="opentopography")
     load_release = opentopography_naburelease(start=harvest)
@@ -804,11 +827,14 @@ def harvest_opentopography():
     load_prov = opentopography_nabuprov(start=load_prune)
     load_org = opentopography_nabuorg(start=load_prov)
 
-    summarize = opentopography_summarize(start=load_uploadrelease)
-    upload_summarize = opentopography_upload_summarize(start=summarize)
+    if(GLEANERIO_SUMMARIZE_GRAPH):
+        summarize = opentopography_summarize(start=load_uploadrelease)
+        upload_summarize = opentopography_upload_summarize(start=summarize)
+
+
 
 # run after load
-    report_msgraph = opentopography_missingreport_graph(start=summarize)
+    report_msgraph = opentopography_missingreport_graph(start=load_prov)
     report_graph = opentopography_graph_reports(start=report_msgraph)
 
 

--- a/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_r2r.py
+++ b/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_r2r.py
@@ -12,10 +12,12 @@ from docker.types import RestartPolicy, ServiceMode
 from ec.gleanerio.gleaner import getGleaner, getSitemapSourcesFromGleaner, endpointUpdateNamespace
 import json
 
+from ec.graph.release_graph import ReleaseGraph
 from minio import Minio
 from minio.error import S3Error
 from datetime import datetime
-from ec.reporting.report import missingReport, generateGraphReportsRepo, reportTypes, generateIdentifierRepo
+from ec.reporting.report import missingReport, generateGraphReportsRepo, reportTypes, generateIdentifierRepo, \
+    generateGraphReportsRelease
 from ec.datastore import s3
 from ec.summarize import summaryDF2ttl, get_summary4graph, get_summary4repoSubset
 from ec.graph.manageGraph import ManageBlazegraph as mg
@@ -81,6 +83,7 @@ GLEANERIO_GLEANER_DOCKER_CONFIG=str(os.environ.get('GLEANERIO_GLEANER_DOCKER_CON
 GLEANERIO_NABU_DOCKER_CONFIG=str(os.environ.get('GLEANERIO_NABU_DOCKER_CONFIG', 'nabu'))
 #GLEANERIO_SUMMARY_GRAPH_ENDPOINT = os.environ.get('GLEANERIO_SUMMARY_GRAPH_ENDPOINT')
 GLEANERIO_SUMMARY_GRAPH_NAMESPACE = os.environ.get('GLEANERIO_SUMMARY_GRAPH_NAMESPACE',f"{GLEANER_GRAPH_NAMESPACE}_summary" )
+GLEANERIO_SUMMARIZE_GRAPH=(os.getenv('GLEANERIO_SUMMARIZE_GRAPH', 'False').lower()  == 'true')
 
 SUMMARY_PATH = 'graphs/summary'
 RELEASE_PATH = 'graphs/latest'
@@ -174,17 +177,28 @@ def s3loader(data, name):
                       content_type="text/plain"
                          )
     get_dagster_logger().info(f"Log uploaded: {str(objPrefix)}")
-def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_graphEndpoint()):
-    # revision of EC utilities, will have a insertFromURL
-    #instance =  mg.ManageBlazegraph(os.environ.get('GLEANER_GRAPH_URL'),os.environ.get('GLEANER_GRAPH_NAMESPACE') )
-    proto = "http"
 
+def _releaseUrl( source, path=RELEASE_PATH, extension="nq"):
+    proto = "http"
     if GLEANER_MINIO_USE_SSL:
         proto = "https"
-    port = GLEANER_MINIO_PORT
     address = _pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT)
     bucket = GLEANER_MINIO_BUCKET
     release_url = f"{proto}://{address}/{bucket}/{path}/{source}_release.{extension}"
+    return release_url
+
+def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_graphEndpoint()):
+    # revision of EC utilities, will have a insertFromURL
+    #instance =  mg.ManageBlazegraph(os.environ.get('GLEANER_GRAPH_URL'),os.environ.get('GLEANER_GRAPH_NAMESPACE') )
+    # proto = "http"
+    #
+    # if GLEANER_MINIO_USE_SSL:
+    #     proto = "https"
+    # port = GLEANER_MINIO_PORT
+    # address = _pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT)
+    # bucket = GLEANER_MINIO_BUCKET
+    # release_url = f"{proto}://{address}/{bucket}/{path}/{source}_release.{extension}"
+
     # BLAZEGRAPH SPECIFIC
     # url = f"{_graphEndpoint()}?uri={release_url}"  # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql?uri={release_url}"
     # get_dagster_logger().info(f'graph: insert "{source}" to {url} ')
@@ -201,6 +215,7 @@ def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_grap
     #     get_dagster_logger().info(f'graph: error')
     #     raise Exception(f' graph: insert failed: status:{r.status_code}')
 
+    release_url = _releaseUrl(source, path, extension)
     ### GENERIC LOAD FROM
     url = f"{graphendpoint}" # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql?uri={release_url}"
     get_dagster_logger().info(f'graph: insert "{source}" to {url} ')
@@ -685,9 +700,10 @@ def r2r_graph_reports(context) :
 
     graphendpoint = _graphEndpoint() # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql"
 
-    milled = False
-    summon = True
-    returned_value = generateGraphReportsRepo(source_name,  graphendpoint, reportList=reportTypes["repo_detailed"])
+
+    #returned_value = generateGraphReportsRepo(source_name,  graphendpoint, reportList=reportTypes["repo_detailed"])
+    s3FileUrl = _releaseUrl(source_name )
+    returned_value = generateGraphReportsRelease(source_name,s3FileUrl)
     r = str('returned value:{}'.format(returned_value))
     #report = json.dumps(returned_value, indent=2) # value already json.dumps
     report = returned_value
@@ -738,7 +754,13 @@ def r2r_summarize(context) :
 
     try:
 
-        summarydf = get_summary4repoSubset(endpoint, source_name)
+       # summarydf = get_summary4repoSubset(endpoint, source_name)
+        rg = ReleaseGraph()
+        rg.read_release(_pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT),
+                        bucket,
+                        source_name,
+                        options=MINIO_OPTIONS)
+        summarydf = rg.summarize()
         nt, g = summaryDF2ttl(summarydf, source_name)  # let's try the new generator
         summaryttl = g.serialize(format='longturtle')
         # Lets always write out file to s3, and insert as a separate process
@@ -791,10 +813,11 @@ def harvest_r2r():
 # defingin nothing dependencies
     # https://docs.dagster.io/concepts/ops-jobs-graphs/graphs#defining-nothing-dependencies
 
-    report_ms3 = r2r_missingreport_s3(start=harvest)
+    report_bucketurl = r2r_bucket_urls(start=harvest)
+    report_ms3 = r2r_missingreport_s3(start=report_bucketurl)
     report_idstat = r2r_identifier_stats(start=report_ms3)
     # for some reason, this causes a msg parameter missing
-    report_bucketurl = r2r_bucket_urls(start=report_idstat)
+
 
     #report1 = missingreport_s3(harvest, source="r2r")
     load_release = r2r_naburelease(start=harvest)
@@ -804,11 +827,14 @@ def harvest_r2r():
     load_prov = r2r_nabuprov(start=load_prune)
     load_org = r2r_nabuorg(start=load_prov)
 
-    summarize = r2r_summarize(start=load_uploadrelease)
-    upload_summarize = r2r_upload_summarize(start=summarize)
+    if(GLEANERIO_SUMMARIZE_GRAPH):
+        summarize = r2r_summarize(start=load_uploadrelease)
+        upload_summarize = r2r_upload_summarize(start=summarize)
+
+
 
 # run after load
-    report_msgraph = r2r_missingreport_graph(start=summarize)
+    report_msgraph = r2r_missingreport_graph(start=load_prov)
     report_graph = r2r_graph_reports(start=report_msgraph)
 
 

--- a/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_resource_registry.py
+++ b/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_resource_registry.py
@@ -12,10 +12,12 @@ from docker.types import RestartPolicy, ServiceMode
 from ec.gleanerio.gleaner import getGleaner, getSitemapSourcesFromGleaner, endpointUpdateNamespace
 import json
 
+from ec.graph.release_graph import ReleaseGraph
 from minio import Minio
 from minio.error import S3Error
 from datetime import datetime
-from ec.reporting.report import missingReport, generateGraphReportsRepo, reportTypes, generateIdentifierRepo
+from ec.reporting.report import missingReport, generateGraphReportsRepo, reportTypes, generateIdentifierRepo, \
+    generateGraphReportsRelease
 from ec.datastore import s3
 from ec.summarize import summaryDF2ttl, get_summary4graph, get_summary4repoSubset
 from ec.graph.manageGraph import ManageBlazegraph as mg
@@ -81,6 +83,7 @@ GLEANERIO_GLEANER_DOCKER_CONFIG=str(os.environ.get('GLEANERIO_GLEANER_DOCKER_CON
 GLEANERIO_NABU_DOCKER_CONFIG=str(os.environ.get('GLEANERIO_NABU_DOCKER_CONFIG', 'nabu'))
 #GLEANERIO_SUMMARY_GRAPH_ENDPOINT = os.environ.get('GLEANERIO_SUMMARY_GRAPH_ENDPOINT')
 GLEANERIO_SUMMARY_GRAPH_NAMESPACE = os.environ.get('GLEANERIO_SUMMARY_GRAPH_NAMESPACE',f"{GLEANER_GRAPH_NAMESPACE}_summary" )
+GLEANERIO_SUMMARIZE_GRAPH=(os.getenv('GLEANERIO_SUMMARIZE_GRAPH', 'False').lower()  == 'true')
 
 SUMMARY_PATH = 'graphs/summary'
 RELEASE_PATH = 'graphs/latest'
@@ -174,17 +177,28 @@ def s3loader(data, name):
                       content_type="text/plain"
                          )
     get_dagster_logger().info(f"Log uploaded: {str(objPrefix)}")
-def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_graphEndpoint()):
-    # revision of EC utilities, will have a insertFromURL
-    #instance =  mg.ManageBlazegraph(os.environ.get('GLEANER_GRAPH_URL'),os.environ.get('GLEANER_GRAPH_NAMESPACE') )
-    proto = "http"
 
+def _releaseUrl( source, path=RELEASE_PATH, extension="nq"):
+    proto = "http"
     if GLEANER_MINIO_USE_SSL:
         proto = "https"
-    port = GLEANER_MINIO_PORT
     address = _pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT)
     bucket = GLEANER_MINIO_BUCKET
     release_url = f"{proto}://{address}/{bucket}/{path}/{source}_release.{extension}"
+    return release_url
+
+def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_graphEndpoint()):
+    # revision of EC utilities, will have a insertFromURL
+    #instance =  mg.ManageBlazegraph(os.environ.get('GLEANER_GRAPH_URL'),os.environ.get('GLEANER_GRAPH_NAMESPACE') )
+    # proto = "http"
+    #
+    # if GLEANER_MINIO_USE_SSL:
+    #     proto = "https"
+    # port = GLEANER_MINIO_PORT
+    # address = _pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT)
+    # bucket = GLEANER_MINIO_BUCKET
+    # release_url = f"{proto}://{address}/{bucket}/{path}/{source}_release.{extension}"
+
     # BLAZEGRAPH SPECIFIC
     # url = f"{_graphEndpoint()}?uri={release_url}"  # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql?uri={release_url}"
     # get_dagster_logger().info(f'graph: insert "{source}" to {url} ')
@@ -201,6 +215,7 @@ def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_grap
     #     get_dagster_logger().info(f'graph: error')
     #     raise Exception(f' graph: insert failed: status:{r.status_code}')
 
+    release_url = _releaseUrl(source, path, extension)
     ### GENERIC LOAD FROM
     url = f"{graphendpoint}" # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql?uri={release_url}"
     get_dagster_logger().info(f'graph: insert "{source}" to {url} ')
@@ -685,9 +700,10 @@ def resource_registry_graph_reports(context) :
 
     graphendpoint = _graphEndpoint() # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql"
 
-    milled = False
-    summon = True
-    returned_value = generateGraphReportsRepo(source_name,  graphendpoint, reportList=reportTypes["repo_detailed"])
+
+    #returned_value = generateGraphReportsRepo(source_name,  graphendpoint, reportList=reportTypes["repo_detailed"])
+    s3FileUrl = _releaseUrl(source_name )
+    returned_value = generateGraphReportsRelease(source_name,s3FileUrl)
     r = str('returned value:{}'.format(returned_value))
     #report = json.dumps(returned_value, indent=2) # value already json.dumps
     report = returned_value
@@ -738,7 +754,13 @@ def resource_registry_summarize(context) :
 
     try:
 
-        summarydf = get_summary4repoSubset(endpoint, source_name)
+       # summarydf = get_summary4repoSubset(endpoint, source_name)
+        rg = ReleaseGraph()
+        rg.read_release(_pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT),
+                        bucket,
+                        source_name,
+                        options=MINIO_OPTIONS)
+        summarydf = rg.summarize()
         nt, g = summaryDF2ttl(summarydf, source_name)  # let's try the new generator
         summaryttl = g.serialize(format='longturtle')
         # Lets always write out file to s3, and insert as a separate process
@@ -791,10 +813,11 @@ def harvest_resource_registry():
 # defingin nothing dependencies
     # https://docs.dagster.io/concepts/ops-jobs-graphs/graphs#defining-nothing-dependencies
 
-    report_ms3 = resource_registry_missingreport_s3(start=harvest)
+    report_bucketurl = resource_registry_bucket_urls(start=harvest)
+    report_ms3 = resource_registry_missingreport_s3(start=report_bucketurl)
     report_idstat = resource_registry_identifier_stats(start=report_ms3)
     # for some reason, this causes a msg parameter missing
-    report_bucketurl = resource_registry_bucket_urls(start=report_idstat)
+
 
     #report1 = missingreport_s3(harvest, source="resource_registry")
     load_release = resource_registry_naburelease(start=harvest)
@@ -804,11 +827,14 @@ def harvest_resource_registry():
     load_prov = resource_registry_nabuprov(start=load_prune)
     load_org = resource_registry_nabuorg(start=load_prov)
 
-    summarize = resource_registry_summarize(start=load_uploadrelease)
-    upload_summarize = resource_registry_upload_summarize(start=summarize)
+    if(GLEANERIO_SUMMARIZE_GRAPH):
+        summarize = resource_registry_summarize(start=load_uploadrelease)
+        upload_summarize = resource_registry_upload_summarize(start=summarize)
+
+
 
 # run after load
-    report_msgraph = resource_registry_missingreport_graph(start=summarize)
+    report_msgraph = resource_registry_missingreport_graph(start=load_prov)
     report_graph = resource_registry_graph_reports(start=report_msgraph)
 
 

--- a/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_ssdbiodp.py
+++ b/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_ssdbiodp.py
@@ -12,10 +12,12 @@ from docker.types import RestartPolicy, ServiceMode
 from ec.gleanerio.gleaner import getGleaner, getSitemapSourcesFromGleaner, endpointUpdateNamespace
 import json
 
+from ec.graph.release_graph import ReleaseGraph
 from minio import Minio
 from minio.error import S3Error
 from datetime import datetime
-from ec.reporting.report import missingReport, generateGraphReportsRepo, reportTypes, generateIdentifierRepo
+from ec.reporting.report import missingReport, generateGraphReportsRepo, reportTypes, generateIdentifierRepo, \
+    generateGraphReportsRelease
 from ec.datastore import s3
 from ec.summarize import summaryDF2ttl, get_summary4graph, get_summary4repoSubset
 from ec.graph.manageGraph import ManageBlazegraph as mg
@@ -81,6 +83,7 @@ GLEANERIO_GLEANER_DOCKER_CONFIG=str(os.environ.get('GLEANERIO_GLEANER_DOCKER_CON
 GLEANERIO_NABU_DOCKER_CONFIG=str(os.environ.get('GLEANERIO_NABU_DOCKER_CONFIG', 'nabu'))
 #GLEANERIO_SUMMARY_GRAPH_ENDPOINT = os.environ.get('GLEANERIO_SUMMARY_GRAPH_ENDPOINT')
 GLEANERIO_SUMMARY_GRAPH_NAMESPACE = os.environ.get('GLEANERIO_SUMMARY_GRAPH_NAMESPACE',f"{GLEANER_GRAPH_NAMESPACE}_summary" )
+GLEANERIO_SUMMARIZE_GRAPH=(os.getenv('GLEANERIO_SUMMARIZE_GRAPH', 'False').lower()  == 'true')
 
 SUMMARY_PATH = 'graphs/summary'
 RELEASE_PATH = 'graphs/latest'
@@ -174,17 +177,28 @@ def s3loader(data, name):
                       content_type="text/plain"
                          )
     get_dagster_logger().info(f"Log uploaded: {str(objPrefix)}")
-def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_graphEndpoint()):
-    # revision of EC utilities, will have a insertFromURL
-    #instance =  mg.ManageBlazegraph(os.environ.get('GLEANER_GRAPH_URL'),os.environ.get('GLEANER_GRAPH_NAMESPACE') )
-    proto = "http"
 
+def _releaseUrl( source, path=RELEASE_PATH, extension="nq"):
+    proto = "http"
     if GLEANER_MINIO_USE_SSL:
         proto = "https"
-    port = GLEANER_MINIO_PORT
     address = _pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT)
     bucket = GLEANER_MINIO_BUCKET
     release_url = f"{proto}://{address}/{bucket}/{path}/{source}_release.{extension}"
+    return release_url
+
+def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_graphEndpoint()):
+    # revision of EC utilities, will have a insertFromURL
+    #instance =  mg.ManageBlazegraph(os.environ.get('GLEANER_GRAPH_URL'),os.environ.get('GLEANER_GRAPH_NAMESPACE') )
+    # proto = "http"
+    #
+    # if GLEANER_MINIO_USE_SSL:
+    #     proto = "https"
+    # port = GLEANER_MINIO_PORT
+    # address = _pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT)
+    # bucket = GLEANER_MINIO_BUCKET
+    # release_url = f"{proto}://{address}/{bucket}/{path}/{source}_release.{extension}"
+
     # BLAZEGRAPH SPECIFIC
     # url = f"{_graphEndpoint()}?uri={release_url}"  # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql?uri={release_url}"
     # get_dagster_logger().info(f'graph: insert "{source}" to {url} ')
@@ -201,6 +215,7 @@ def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_grap
     #     get_dagster_logger().info(f'graph: error')
     #     raise Exception(f' graph: insert failed: status:{r.status_code}')
 
+    release_url = _releaseUrl(source, path, extension)
     ### GENERIC LOAD FROM
     url = f"{graphendpoint}" # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql?uri={release_url}"
     get_dagster_logger().info(f'graph: insert "{source}" to {url} ')
@@ -685,9 +700,10 @@ def ssdbiodp_graph_reports(context) :
 
     graphendpoint = _graphEndpoint() # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql"
 
-    milled = False
-    summon = True
-    returned_value = generateGraphReportsRepo(source_name,  graphendpoint, reportList=reportTypes["repo_detailed"])
+
+    #returned_value = generateGraphReportsRepo(source_name,  graphendpoint, reportList=reportTypes["repo_detailed"])
+    s3FileUrl = _releaseUrl(source_name )
+    returned_value = generateGraphReportsRelease(source_name,s3FileUrl)
     r = str('returned value:{}'.format(returned_value))
     #report = json.dumps(returned_value, indent=2) # value already json.dumps
     report = returned_value
@@ -738,7 +754,13 @@ def ssdbiodp_summarize(context) :
 
     try:
 
-        summarydf = get_summary4repoSubset(endpoint, source_name)
+       # summarydf = get_summary4repoSubset(endpoint, source_name)
+        rg = ReleaseGraph()
+        rg.read_release(_pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT),
+                        bucket,
+                        source_name,
+                        options=MINIO_OPTIONS)
+        summarydf = rg.summarize()
         nt, g = summaryDF2ttl(summarydf, source_name)  # let's try the new generator
         summaryttl = g.serialize(format='longturtle')
         # Lets always write out file to s3, and insert as a separate process
@@ -791,10 +813,11 @@ def harvest_ssdbiodp():
 # defingin nothing dependencies
     # https://docs.dagster.io/concepts/ops-jobs-graphs/graphs#defining-nothing-dependencies
 
-    report_ms3 = ssdbiodp_missingreport_s3(start=harvest)
+    report_bucketurl = ssdbiodp_bucket_urls(start=harvest)
+    report_ms3 = ssdbiodp_missingreport_s3(start=report_bucketurl)
     report_idstat = ssdbiodp_identifier_stats(start=report_ms3)
     # for some reason, this causes a msg parameter missing
-    report_bucketurl = ssdbiodp_bucket_urls(start=report_idstat)
+
 
     #report1 = missingreport_s3(harvest, source="ssdbiodp")
     load_release = ssdbiodp_naburelease(start=harvest)
@@ -804,11 +827,14 @@ def harvest_ssdbiodp():
     load_prov = ssdbiodp_nabuprov(start=load_prune)
     load_org = ssdbiodp_nabuorg(start=load_prov)
 
-    summarize = ssdbiodp_summarize(start=load_uploadrelease)
-    upload_summarize = ssdbiodp_upload_summarize(start=summarize)
+    if(GLEANERIO_SUMMARIZE_GRAPH):
+        summarize = ssdbiodp_summarize(start=load_uploadrelease)
+        upload_summarize = ssdbiodp_upload_summarize(start=summarize)
+
+
 
 # run after load
-    report_msgraph = ssdbiodp_missingreport_graph(start=summarize)
+    report_msgraph = ssdbiodp_missingreport_graph(start=load_prov)
     report_graph = ssdbiodp_graph_reports(start=report_msgraph)
 
 

--- a/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_ucar.py
+++ b/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_ucar.py
@@ -12,10 +12,12 @@ from docker.types import RestartPolicy, ServiceMode
 from ec.gleanerio.gleaner import getGleaner, getSitemapSourcesFromGleaner, endpointUpdateNamespace
 import json
 
+from ec.graph.release_graph import ReleaseGraph
 from minio import Minio
 from minio.error import S3Error
 from datetime import datetime
-from ec.reporting.report import missingReport, generateGraphReportsRepo, reportTypes, generateIdentifierRepo
+from ec.reporting.report import missingReport, generateGraphReportsRepo, reportTypes, generateIdentifierRepo, \
+    generateGraphReportsRelease
 from ec.datastore import s3
 from ec.summarize import summaryDF2ttl, get_summary4graph, get_summary4repoSubset
 from ec.graph.manageGraph import ManageBlazegraph as mg
@@ -81,6 +83,7 @@ GLEANERIO_GLEANER_DOCKER_CONFIG=str(os.environ.get('GLEANERIO_GLEANER_DOCKER_CON
 GLEANERIO_NABU_DOCKER_CONFIG=str(os.environ.get('GLEANERIO_NABU_DOCKER_CONFIG', 'nabu'))
 #GLEANERIO_SUMMARY_GRAPH_ENDPOINT = os.environ.get('GLEANERIO_SUMMARY_GRAPH_ENDPOINT')
 GLEANERIO_SUMMARY_GRAPH_NAMESPACE = os.environ.get('GLEANERIO_SUMMARY_GRAPH_NAMESPACE',f"{GLEANER_GRAPH_NAMESPACE}_summary" )
+GLEANERIO_SUMMARIZE_GRAPH=(os.getenv('GLEANERIO_SUMMARIZE_GRAPH', 'False').lower()  == 'true')
 
 SUMMARY_PATH = 'graphs/summary'
 RELEASE_PATH = 'graphs/latest'
@@ -174,17 +177,28 @@ def s3loader(data, name):
                       content_type="text/plain"
                          )
     get_dagster_logger().info(f"Log uploaded: {str(objPrefix)}")
-def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_graphEndpoint()):
-    # revision of EC utilities, will have a insertFromURL
-    #instance =  mg.ManageBlazegraph(os.environ.get('GLEANER_GRAPH_URL'),os.environ.get('GLEANER_GRAPH_NAMESPACE') )
-    proto = "http"
 
+def _releaseUrl( source, path=RELEASE_PATH, extension="nq"):
+    proto = "http"
     if GLEANER_MINIO_USE_SSL:
         proto = "https"
-    port = GLEANER_MINIO_PORT
     address = _pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT)
     bucket = GLEANER_MINIO_BUCKET
     release_url = f"{proto}://{address}/{bucket}/{path}/{source}_release.{extension}"
+    return release_url
+
+def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_graphEndpoint()):
+    # revision of EC utilities, will have a insertFromURL
+    #instance =  mg.ManageBlazegraph(os.environ.get('GLEANER_GRAPH_URL'),os.environ.get('GLEANER_GRAPH_NAMESPACE') )
+    # proto = "http"
+    #
+    # if GLEANER_MINIO_USE_SSL:
+    #     proto = "https"
+    # port = GLEANER_MINIO_PORT
+    # address = _pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT)
+    # bucket = GLEANER_MINIO_BUCKET
+    # release_url = f"{proto}://{address}/{bucket}/{path}/{source}_release.{extension}"
+
     # BLAZEGRAPH SPECIFIC
     # url = f"{_graphEndpoint()}?uri={release_url}"  # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql?uri={release_url}"
     # get_dagster_logger().info(f'graph: insert "{source}" to {url} ')
@@ -201,6 +215,7 @@ def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_grap
     #     get_dagster_logger().info(f'graph: error')
     #     raise Exception(f' graph: insert failed: status:{r.status_code}')
 
+    release_url = _releaseUrl(source, path, extension)
     ### GENERIC LOAD FROM
     url = f"{graphendpoint}" # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql?uri={release_url}"
     get_dagster_logger().info(f'graph: insert "{source}" to {url} ')
@@ -685,9 +700,10 @@ def ucar_graph_reports(context) :
 
     graphendpoint = _graphEndpoint() # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql"
 
-    milled = False
-    summon = True
-    returned_value = generateGraphReportsRepo(source_name,  graphendpoint, reportList=reportTypes["repo_detailed"])
+
+    #returned_value = generateGraphReportsRepo(source_name,  graphendpoint, reportList=reportTypes["repo_detailed"])
+    s3FileUrl = _releaseUrl(source_name )
+    returned_value = generateGraphReportsRelease(source_name,s3FileUrl)
     r = str('returned value:{}'.format(returned_value))
     #report = json.dumps(returned_value, indent=2) # value already json.dumps
     report = returned_value
@@ -738,7 +754,13 @@ def ucar_summarize(context) :
 
     try:
 
-        summarydf = get_summary4repoSubset(endpoint, source_name)
+       # summarydf = get_summary4repoSubset(endpoint, source_name)
+        rg = ReleaseGraph()
+        rg.read_release(_pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT),
+                        bucket,
+                        source_name,
+                        options=MINIO_OPTIONS)
+        summarydf = rg.summarize()
         nt, g = summaryDF2ttl(summarydf, source_name)  # let's try the new generator
         summaryttl = g.serialize(format='longturtle')
         # Lets always write out file to s3, and insert as a separate process
@@ -791,10 +813,11 @@ def harvest_ucar():
 # defingin nothing dependencies
     # https://docs.dagster.io/concepts/ops-jobs-graphs/graphs#defining-nothing-dependencies
 
-    report_ms3 = ucar_missingreport_s3(start=harvest)
+    report_bucketurl = ucar_bucket_urls(start=harvest)
+    report_ms3 = ucar_missingreport_s3(start=report_bucketurl)
     report_idstat = ucar_identifier_stats(start=report_ms3)
     # for some reason, this causes a msg parameter missing
-    report_bucketurl = ucar_bucket_urls(start=report_idstat)
+
 
     #report1 = missingreport_s3(harvest, source="ucar")
     load_release = ucar_naburelease(start=harvest)
@@ -804,11 +827,14 @@ def harvest_ucar():
     load_prov = ucar_nabuprov(start=load_prune)
     load_org = ucar_nabuorg(start=load_prov)
 
-    summarize = ucar_summarize(start=load_uploadrelease)
-    upload_summarize = ucar_upload_summarize(start=summarize)
+    if(GLEANERIO_SUMMARIZE_GRAPH):
+        summarize = ucar_summarize(start=load_uploadrelease)
+        upload_summarize = ucar_upload_summarize(start=summarize)
+
+
 
 # run after load
-    report_msgraph = ucar_missingreport_graph(start=summarize)
+    report_msgraph = ucar_missingreport_graph(start=load_prov)
     report_graph = ucar_graph_reports(start=report_msgraph)
 
 

--- a/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_unavco.py
+++ b/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_unavco.py
@@ -12,10 +12,12 @@ from docker.types import RestartPolicy, ServiceMode
 from ec.gleanerio.gleaner import getGleaner, getSitemapSourcesFromGleaner, endpointUpdateNamespace
 import json
 
+from ec.graph.release_graph import ReleaseGraph
 from minio import Minio
 from minio.error import S3Error
 from datetime import datetime
-from ec.reporting.report import missingReport, generateGraphReportsRepo, reportTypes, generateIdentifierRepo
+from ec.reporting.report import missingReport, generateGraphReportsRepo, reportTypes, generateIdentifierRepo, \
+    generateGraphReportsRelease
 from ec.datastore import s3
 from ec.summarize import summaryDF2ttl, get_summary4graph, get_summary4repoSubset
 from ec.graph.manageGraph import ManageBlazegraph as mg
@@ -81,6 +83,7 @@ GLEANERIO_GLEANER_DOCKER_CONFIG=str(os.environ.get('GLEANERIO_GLEANER_DOCKER_CON
 GLEANERIO_NABU_DOCKER_CONFIG=str(os.environ.get('GLEANERIO_NABU_DOCKER_CONFIG', 'nabu'))
 #GLEANERIO_SUMMARY_GRAPH_ENDPOINT = os.environ.get('GLEANERIO_SUMMARY_GRAPH_ENDPOINT')
 GLEANERIO_SUMMARY_GRAPH_NAMESPACE = os.environ.get('GLEANERIO_SUMMARY_GRAPH_NAMESPACE',f"{GLEANER_GRAPH_NAMESPACE}_summary" )
+GLEANERIO_SUMMARIZE_GRAPH=(os.getenv('GLEANERIO_SUMMARIZE_GRAPH', 'False').lower()  == 'true')
 
 SUMMARY_PATH = 'graphs/summary'
 RELEASE_PATH = 'graphs/latest'
@@ -174,17 +177,28 @@ def s3loader(data, name):
                       content_type="text/plain"
                          )
     get_dagster_logger().info(f"Log uploaded: {str(objPrefix)}")
-def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_graphEndpoint()):
-    # revision of EC utilities, will have a insertFromURL
-    #instance =  mg.ManageBlazegraph(os.environ.get('GLEANER_GRAPH_URL'),os.environ.get('GLEANER_GRAPH_NAMESPACE') )
-    proto = "http"
 
+def _releaseUrl( source, path=RELEASE_PATH, extension="nq"):
+    proto = "http"
     if GLEANER_MINIO_USE_SSL:
         proto = "https"
-    port = GLEANER_MINIO_PORT
     address = _pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT)
     bucket = GLEANER_MINIO_BUCKET
     release_url = f"{proto}://{address}/{bucket}/{path}/{source}_release.{extension}"
+    return release_url
+
+def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_graphEndpoint()):
+    # revision of EC utilities, will have a insertFromURL
+    #instance =  mg.ManageBlazegraph(os.environ.get('GLEANER_GRAPH_URL'),os.environ.get('GLEANER_GRAPH_NAMESPACE') )
+    # proto = "http"
+    #
+    # if GLEANER_MINIO_USE_SSL:
+    #     proto = "https"
+    # port = GLEANER_MINIO_PORT
+    # address = _pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT)
+    # bucket = GLEANER_MINIO_BUCKET
+    # release_url = f"{proto}://{address}/{bucket}/{path}/{source}_release.{extension}"
+
     # BLAZEGRAPH SPECIFIC
     # url = f"{_graphEndpoint()}?uri={release_url}"  # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql?uri={release_url}"
     # get_dagster_logger().info(f'graph: insert "{source}" to {url} ')
@@ -201,6 +215,7 @@ def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_grap
     #     get_dagster_logger().info(f'graph: error')
     #     raise Exception(f' graph: insert failed: status:{r.status_code}')
 
+    release_url = _releaseUrl(source, path, extension)
     ### GENERIC LOAD FROM
     url = f"{graphendpoint}" # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql?uri={release_url}"
     get_dagster_logger().info(f'graph: insert "{source}" to {url} ')
@@ -685,9 +700,10 @@ def unavco_graph_reports(context) :
 
     graphendpoint = _graphEndpoint() # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql"
 
-    milled = False
-    summon = True
-    returned_value = generateGraphReportsRepo(source_name,  graphendpoint, reportList=reportTypes["repo_detailed"])
+
+    #returned_value = generateGraphReportsRepo(source_name,  graphendpoint, reportList=reportTypes["repo_detailed"])
+    s3FileUrl = _releaseUrl(source_name )
+    returned_value = generateGraphReportsRelease(source_name,s3FileUrl)
     r = str('returned value:{}'.format(returned_value))
     #report = json.dumps(returned_value, indent=2) # value already json.dumps
     report = returned_value
@@ -738,7 +754,13 @@ def unavco_summarize(context) :
 
     try:
 
-        summarydf = get_summary4repoSubset(endpoint, source_name)
+       # summarydf = get_summary4repoSubset(endpoint, source_name)
+        rg = ReleaseGraph()
+        rg.read_release(_pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT),
+                        bucket,
+                        source_name,
+                        options=MINIO_OPTIONS)
+        summarydf = rg.summarize()
         nt, g = summaryDF2ttl(summarydf, source_name)  # let's try the new generator
         summaryttl = g.serialize(format='longturtle')
         # Lets always write out file to s3, and insert as a separate process
@@ -791,10 +813,11 @@ def harvest_unavco():
 # defingin nothing dependencies
     # https://docs.dagster.io/concepts/ops-jobs-graphs/graphs#defining-nothing-dependencies
 
-    report_ms3 = unavco_missingreport_s3(start=harvest)
+    report_bucketurl = unavco_bucket_urls(start=harvest)
+    report_ms3 = unavco_missingreport_s3(start=report_bucketurl)
     report_idstat = unavco_identifier_stats(start=report_ms3)
     # for some reason, this causes a msg parameter missing
-    report_bucketurl = unavco_bucket_urls(start=report_idstat)
+
 
     #report1 = missingreport_s3(harvest, source="unavco")
     load_release = unavco_naburelease(start=harvest)
@@ -804,11 +827,14 @@ def harvest_unavco():
     load_prov = unavco_nabuprov(start=load_prune)
     load_org = unavco_nabuorg(start=load_prov)
 
-    summarize = unavco_summarize(start=load_uploadrelease)
-    upload_summarize = unavco_upload_summarize(start=summarize)
+    if(GLEANERIO_SUMMARIZE_GRAPH):
+        summarize = unavco_summarize(start=load_uploadrelease)
+        upload_summarize = unavco_upload_summarize(start=summarize)
+
+
 
 # run after load
-    report_msgraph = unavco_missingreport_graph(start=summarize)
+    report_msgraph = unavco_missingreport_graph(start=load_prov)
     report_graph = unavco_graph_reports(start=report_msgraph)
 
 

--- a/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_unidata.py
+++ b/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_unidata.py
@@ -12,10 +12,12 @@ from docker.types import RestartPolicy, ServiceMode
 from ec.gleanerio.gleaner import getGleaner, getSitemapSourcesFromGleaner, endpointUpdateNamespace
 import json
 
+from ec.graph.release_graph import ReleaseGraph
 from minio import Minio
 from minio.error import S3Error
 from datetime import datetime
-from ec.reporting.report import missingReport, generateGraphReportsRepo, reportTypes, generateIdentifierRepo
+from ec.reporting.report import missingReport, generateGraphReportsRepo, reportTypes, generateIdentifierRepo, \
+    generateGraphReportsRelease
 from ec.datastore import s3
 from ec.summarize import summaryDF2ttl, get_summary4graph, get_summary4repoSubset
 from ec.graph.manageGraph import ManageBlazegraph as mg
@@ -81,6 +83,7 @@ GLEANERIO_GLEANER_DOCKER_CONFIG=str(os.environ.get('GLEANERIO_GLEANER_DOCKER_CON
 GLEANERIO_NABU_DOCKER_CONFIG=str(os.environ.get('GLEANERIO_NABU_DOCKER_CONFIG', 'nabu'))
 #GLEANERIO_SUMMARY_GRAPH_ENDPOINT = os.environ.get('GLEANERIO_SUMMARY_GRAPH_ENDPOINT')
 GLEANERIO_SUMMARY_GRAPH_NAMESPACE = os.environ.get('GLEANERIO_SUMMARY_GRAPH_NAMESPACE',f"{GLEANER_GRAPH_NAMESPACE}_summary" )
+GLEANERIO_SUMMARIZE_GRAPH=(os.getenv('GLEANERIO_SUMMARIZE_GRAPH', 'False').lower()  == 'true')
 
 SUMMARY_PATH = 'graphs/summary'
 RELEASE_PATH = 'graphs/latest'
@@ -174,17 +177,28 @@ def s3loader(data, name):
                       content_type="text/plain"
                          )
     get_dagster_logger().info(f"Log uploaded: {str(objPrefix)}")
-def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_graphEndpoint()):
-    # revision of EC utilities, will have a insertFromURL
-    #instance =  mg.ManageBlazegraph(os.environ.get('GLEANER_GRAPH_URL'),os.environ.get('GLEANER_GRAPH_NAMESPACE') )
-    proto = "http"
 
+def _releaseUrl( source, path=RELEASE_PATH, extension="nq"):
+    proto = "http"
     if GLEANER_MINIO_USE_SSL:
         proto = "https"
-    port = GLEANER_MINIO_PORT
     address = _pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT)
     bucket = GLEANER_MINIO_BUCKET
     release_url = f"{proto}://{address}/{bucket}/{path}/{source}_release.{extension}"
+    return release_url
+
+def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_graphEndpoint()):
+    # revision of EC utilities, will have a insertFromURL
+    #instance =  mg.ManageBlazegraph(os.environ.get('GLEANER_GRAPH_URL'),os.environ.get('GLEANER_GRAPH_NAMESPACE') )
+    # proto = "http"
+    #
+    # if GLEANER_MINIO_USE_SSL:
+    #     proto = "https"
+    # port = GLEANER_MINIO_PORT
+    # address = _pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT)
+    # bucket = GLEANER_MINIO_BUCKET
+    # release_url = f"{proto}://{address}/{bucket}/{path}/{source}_release.{extension}"
+
     # BLAZEGRAPH SPECIFIC
     # url = f"{_graphEndpoint()}?uri={release_url}"  # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql?uri={release_url}"
     # get_dagster_logger().info(f'graph: insert "{source}" to {url} ')
@@ -201,6 +215,7 @@ def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_grap
     #     get_dagster_logger().info(f'graph: error')
     #     raise Exception(f' graph: insert failed: status:{r.status_code}')
 
+    release_url = _releaseUrl(source, path, extension)
     ### GENERIC LOAD FROM
     url = f"{graphendpoint}" # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql?uri={release_url}"
     get_dagster_logger().info(f'graph: insert "{source}" to {url} ')
@@ -685,9 +700,10 @@ def unidata_graph_reports(context) :
 
     graphendpoint = _graphEndpoint() # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql"
 
-    milled = False
-    summon = True
-    returned_value = generateGraphReportsRepo(source_name,  graphendpoint, reportList=reportTypes["repo_detailed"])
+
+    #returned_value = generateGraphReportsRepo(source_name,  graphendpoint, reportList=reportTypes["repo_detailed"])
+    s3FileUrl = _releaseUrl(source_name )
+    returned_value = generateGraphReportsRelease(source_name,s3FileUrl)
     r = str('returned value:{}'.format(returned_value))
     #report = json.dumps(returned_value, indent=2) # value already json.dumps
     report = returned_value
@@ -738,7 +754,13 @@ def unidata_summarize(context) :
 
     try:
 
-        summarydf = get_summary4repoSubset(endpoint, source_name)
+       # summarydf = get_summary4repoSubset(endpoint, source_name)
+        rg = ReleaseGraph()
+        rg.read_release(_pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT),
+                        bucket,
+                        source_name,
+                        options=MINIO_OPTIONS)
+        summarydf = rg.summarize()
         nt, g = summaryDF2ttl(summarydf, source_name)  # let's try the new generator
         summaryttl = g.serialize(format='longturtle')
         # Lets always write out file to s3, and insert as a separate process
@@ -791,10 +813,11 @@ def harvest_unidata():
 # defingin nothing dependencies
     # https://docs.dagster.io/concepts/ops-jobs-graphs/graphs#defining-nothing-dependencies
 
-    report_ms3 = unidata_missingreport_s3(start=harvest)
+    report_bucketurl = unidata_bucket_urls(start=harvest)
+    report_ms3 = unidata_missingreport_s3(start=report_bucketurl)
     report_idstat = unidata_identifier_stats(start=report_ms3)
     # for some reason, this causes a msg parameter missing
-    report_bucketurl = unidata_bucket_urls(start=report_idstat)
+
 
     #report1 = missingreport_s3(harvest, source="unidata")
     load_release = unidata_naburelease(start=harvest)
@@ -804,11 +827,14 @@ def harvest_unidata():
     load_prov = unidata_nabuprov(start=load_prune)
     load_org = unidata_nabuorg(start=load_prov)
 
-    summarize = unidata_summarize(start=load_uploadrelease)
-    upload_summarize = unidata_upload_summarize(start=summarize)
+    if(GLEANERIO_SUMMARIZE_GRAPH):
+        summarize = unidata_summarize(start=load_uploadrelease)
+        upload_summarize = unidata_upload_summarize(start=summarize)
+
+
 
 # run after load
-    report_msgraph = unidata_missingreport_graph(start=summarize)
+    report_msgraph = unidata_missingreport_graph(start=load_prov)
     report_graph = unidata_graph_reports(start=report_msgraph)
 
 

--- a/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_usapdc.py
+++ b/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_usapdc.py
@@ -12,10 +12,12 @@ from docker.types import RestartPolicy, ServiceMode
 from ec.gleanerio.gleaner import getGleaner, getSitemapSourcesFromGleaner, endpointUpdateNamespace
 import json
 
+from ec.graph.release_graph import ReleaseGraph
 from minio import Minio
 from minio.error import S3Error
 from datetime import datetime
-from ec.reporting.report import missingReport, generateGraphReportsRepo, reportTypes, generateIdentifierRepo
+from ec.reporting.report import missingReport, generateGraphReportsRepo, reportTypes, generateIdentifierRepo, \
+    generateGraphReportsRelease
 from ec.datastore import s3
 from ec.summarize import summaryDF2ttl, get_summary4graph, get_summary4repoSubset
 from ec.graph.manageGraph import ManageBlazegraph as mg
@@ -81,6 +83,7 @@ GLEANERIO_GLEANER_DOCKER_CONFIG=str(os.environ.get('GLEANERIO_GLEANER_DOCKER_CON
 GLEANERIO_NABU_DOCKER_CONFIG=str(os.environ.get('GLEANERIO_NABU_DOCKER_CONFIG', 'nabu'))
 #GLEANERIO_SUMMARY_GRAPH_ENDPOINT = os.environ.get('GLEANERIO_SUMMARY_GRAPH_ENDPOINT')
 GLEANERIO_SUMMARY_GRAPH_NAMESPACE = os.environ.get('GLEANERIO_SUMMARY_GRAPH_NAMESPACE',f"{GLEANER_GRAPH_NAMESPACE}_summary" )
+GLEANERIO_SUMMARIZE_GRAPH=(os.getenv('GLEANERIO_SUMMARIZE_GRAPH', 'False').lower()  == 'true')
 
 SUMMARY_PATH = 'graphs/summary'
 RELEASE_PATH = 'graphs/latest'
@@ -174,17 +177,28 @@ def s3loader(data, name):
                       content_type="text/plain"
                          )
     get_dagster_logger().info(f"Log uploaded: {str(objPrefix)}")
-def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_graphEndpoint()):
-    # revision of EC utilities, will have a insertFromURL
-    #instance =  mg.ManageBlazegraph(os.environ.get('GLEANER_GRAPH_URL'),os.environ.get('GLEANER_GRAPH_NAMESPACE') )
-    proto = "http"
 
+def _releaseUrl( source, path=RELEASE_PATH, extension="nq"):
+    proto = "http"
     if GLEANER_MINIO_USE_SSL:
         proto = "https"
-    port = GLEANER_MINIO_PORT
     address = _pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT)
     bucket = GLEANER_MINIO_BUCKET
     release_url = f"{proto}://{address}/{bucket}/{path}/{source}_release.{extension}"
+    return release_url
+
+def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_graphEndpoint()):
+    # revision of EC utilities, will have a insertFromURL
+    #instance =  mg.ManageBlazegraph(os.environ.get('GLEANER_GRAPH_URL'),os.environ.get('GLEANER_GRAPH_NAMESPACE') )
+    # proto = "http"
+    #
+    # if GLEANER_MINIO_USE_SSL:
+    #     proto = "https"
+    # port = GLEANER_MINIO_PORT
+    # address = _pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT)
+    # bucket = GLEANER_MINIO_BUCKET
+    # release_url = f"{proto}://{address}/{bucket}/{path}/{source}_release.{extension}"
+
     # BLAZEGRAPH SPECIFIC
     # url = f"{_graphEndpoint()}?uri={release_url}"  # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql?uri={release_url}"
     # get_dagster_logger().info(f'graph: insert "{source}" to {url} ')
@@ -201,6 +215,7 @@ def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_grap
     #     get_dagster_logger().info(f'graph: error')
     #     raise Exception(f' graph: insert failed: status:{r.status_code}')
 
+    release_url = _releaseUrl(source, path, extension)
     ### GENERIC LOAD FROM
     url = f"{graphendpoint}" # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql?uri={release_url}"
     get_dagster_logger().info(f'graph: insert "{source}" to {url} ')
@@ -685,9 +700,10 @@ def usapdc_graph_reports(context) :
 
     graphendpoint = _graphEndpoint() # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql"
 
-    milled = False
-    summon = True
-    returned_value = generateGraphReportsRepo(source_name,  graphendpoint, reportList=reportTypes["repo_detailed"])
+
+    #returned_value = generateGraphReportsRepo(source_name,  graphendpoint, reportList=reportTypes["repo_detailed"])
+    s3FileUrl = _releaseUrl(source_name )
+    returned_value = generateGraphReportsRelease(source_name,s3FileUrl)
     r = str('returned value:{}'.format(returned_value))
     #report = json.dumps(returned_value, indent=2) # value already json.dumps
     report = returned_value
@@ -738,7 +754,13 @@ def usapdc_summarize(context) :
 
     try:
 
-        summarydf = get_summary4repoSubset(endpoint, source_name)
+       # summarydf = get_summary4repoSubset(endpoint, source_name)
+        rg = ReleaseGraph()
+        rg.read_release(_pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT),
+                        bucket,
+                        source_name,
+                        options=MINIO_OPTIONS)
+        summarydf = rg.summarize()
         nt, g = summaryDF2ttl(summarydf, source_name)  # let's try the new generator
         summaryttl = g.serialize(format='longturtle')
         # Lets always write out file to s3, and insert as a separate process
@@ -791,10 +813,11 @@ def harvest_usapdc():
 # defingin nothing dependencies
     # https://docs.dagster.io/concepts/ops-jobs-graphs/graphs#defining-nothing-dependencies
 
-    report_ms3 = usapdc_missingreport_s3(start=harvest)
+    report_bucketurl = usapdc_bucket_urls(start=harvest)
+    report_ms3 = usapdc_missingreport_s3(start=report_bucketurl)
     report_idstat = usapdc_identifier_stats(start=report_ms3)
     # for some reason, this causes a msg parameter missing
-    report_bucketurl = usapdc_bucket_urls(start=report_idstat)
+
 
     #report1 = missingreport_s3(harvest, source="usapdc")
     load_release = usapdc_naburelease(start=harvest)
@@ -804,11 +827,14 @@ def harvest_usapdc():
     load_prov = usapdc_nabuprov(start=load_prune)
     load_org = usapdc_nabuorg(start=load_prov)
 
-    summarize = usapdc_summarize(start=load_uploadrelease)
-    upload_summarize = usapdc_upload_summarize(start=summarize)
+    if(GLEANERIO_SUMMARIZE_GRAPH):
+        summarize = usapdc_summarize(start=load_uploadrelease)
+        upload_summarize = usapdc_upload_summarize(start=summarize)
+
+
 
 # run after load
-    report_msgraph = usapdc_missingreport_graph(start=summarize)
+    report_msgraph = usapdc_missingreport_graph(start=load_prov)
     report_graph = usapdc_graph_reports(start=report_msgraph)
 
 

--- a/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_wifire.py
+++ b/dagster/implnets/generatedCode/implnet-eco/output/ops/implnet_ops_wifire.py
@@ -12,10 +12,12 @@ from docker.types import RestartPolicy, ServiceMode
 from ec.gleanerio.gleaner import getGleaner, getSitemapSourcesFromGleaner, endpointUpdateNamespace
 import json
 
+from ec.graph.release_graph import ReleaseGraph
 from minio import Minio
 from minio.error import S3Error
 from datetime import datetime
-from ec.reporting.report import missingReport, generateGraphReportsRepo, reportTypes, generateIdentifierRepo
+from ec.reporting.report import missingReport, generateGraphReportsRepo, reportTypes, generateIdentifierRepo, \
+    generateGraphReportsRelease
 from ec.datastore import s3
 from ec.summarize import summaryDF2ttl, get_summary4graph, get_summary4repoSubset
 from ec.graph.manageGraph import ManageBlazegraph as mg
@@ -81,6 +83,7 @@ GLEANERIO_GLEANER_DOCKER_CONFIG=str(os.environ.get('GLEANERIO_GLEANER_DOCKER_CON
 GLEANERIO_NABU_DOCKER_CONFIG=str(os.environ.get('GLEANERIO_NABU_DOCKER_CONFIG', 'nabu'))
 #GLEANERIO_SUMMARY_GRAPH_ENDPOINT = os.environ.get('GLEANERIO_SUMMARY_GRAPH_ENDPOINT')
 GLEANERIO_SUMMARY_GRAPH_NAMESPACE = os.environ.get('GLEANERIO_SUMMARY_GRAPH_NAMESPACE',f"{GLEANER_GRAPH_NAMESPACE}_summary" )
+GLEANERIO_SUMMARIZE_GRAPH=(os.getenv('GLEANERIO_SUMMARIZE_GRAPH', 'False').lower()  == 'true')
 
 SUMMARY_PATH = 'graphs/summary'
 RELEASE_PATH = 'graphs/latest'
@@ -174,17 +177,28 @@ def s3loader(data, name):
                       content_type="text/plain"
                          )
     get_dagster_logger().info(f"Log uploaded: {str(objPrefix)}")
-def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_graphEndpoint()):
-    # revision of EC utilities, will have a insertFromURL
-    #instance =  mg.ManageBlazegraph(os.environ.get('GLEANER_GRAPH_URL'),os.environ.get('GLEANER_GRAPH_NAMESPACE') )
-    proto = "http"
 
+def _releaseUrl( source, path=RELEASE_PATH, extension="nq"):
+    proto = "http"
     if GLEANER_MINIO_USE_SSL:
         proto = "https"
-    port = GLEANER_MINIO_PORT
     address = _pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT)
     bucket = GLEANER_MINIO_BUCKET
     release_url = f"{proto}://{address}/{bucket}/{path}/{source}_release.{extension}"
+    return release_url
+
+def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_graphEndpoint()):
+    # revision of EC utilities, will have a insertFromURL
+    #instance =  mg.ManageBlazegraph(os.environ.get('GLEANER_GRAPH_URL'),os.environ.get('GLEANER_GRAPH_NAMESPACE') )
+    # proto = "http"
+    #
+    # if GLEANER_MINIO_USE_SSL:
+    #     proto = "https"
+    # port = GLEANER_MINIO_PORT
+    # address = _pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT)
+    # bucket = GLEANER_MINIO_BUCKET
+    # release_url = f"{proto}://{address}/{bucket}/{path}/{source}_release.{extension}"
+
     # BLAZEGRAPH SPECIFIC
     # url = f"{_graphEndpoint()}?uri={release_url}"  # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql?uri={release_url}"
     # get_dagster_logger().info(f'graph: insert "{source}" to {url} ')
@@ -201,6 +215,7 @@ def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_grap
     #     get_dagster_logger().info(f'graph: error')
     #     raise Exception(f' graph: insert failed: status:{r.status_code}')
 
+    release_url = _releaseUrl(source, path, extension)
     ### GENERIC LOAD FROM
     url = f"{graphendpoint}" # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql?uri={release_url}"
     get_dagster_logger().info(f'graph: insert "{source}" to {url} ')
@@ -685,9 +700,10 @@ def wifire_graph_reports(context) :
 
     graphendpoint = _graphEndpoint() # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql"
 
-    milled = False
-    summon = True
-    returned_value = generateGraphReportsRepo(source_name,  graphendpoint, reportList=reportTypes["repo_detailed"])
+
+    #returned_value = generateGraphReportsRepo(source_name,  graphendpoint, reportList=reportTypes["repo_detailed"])
+    s3FileUrl = _releaseUrl(source_name )
+    returned_value = generateGraphReportsRelease(source_name,s3FileUrl)
     r = str('returned value:{}'.format(returned_value))
     #report = json.dumps(returned_value, indent=2) # value already json.dumps
     report = returned_value
@@ -738,7 +754,13 @@ def wifire_summarize(context) :
 
     try:
 
-        summarydf = get_summary4repoSubset(endpoint, source_name)
+       # summarydf = get_summary4repoSubset(endpoint, source_name)
+        rg = ReleaseGraph()
+        rg.read_release(_pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT),
+                        bucket,
+                        source_name,
+                        options=MINIO_OPTIONS)
+        summarydf = rg.summarize()
         nt, g = summaryDF2ttl(summarydf, source_name)  # let's try the new generator
         summaryttl = g.serialize(format='longturtle')
         # Lets always write out file to s3, and insert as a separate process
@@ -791,10 +813,11 @@ def harvest_wifire():
 # defingin nothing dependencies
     # https://docs.dagster.io/concepts/ops-jobs-graphs/graphs#defining-nothing-dependencies
 
-    report_ms3 = wifire_missingreport_s3(start=harvest)
+    report_bucketurl = wifire_bucket_urls(start=harvest)
+    report_ms3 = wifire_missingreport_s3(start=report_bucketurl)
     report_idstat = wifire_identifier_stats(start=report_ms3)
     # for some reason, this causes a msg parameter missing
-    report_bucketurl = wifire_bucket_urls(start=report_idstat)
+
 
     #report1 = missingreport_s3(harvest, source="wifire")
     load_release = wifire_naburelease(start=harvest)
@@ -804,11 +827,14 @@ def harvest_wifire():
     load_prov = wifire_nabuprov(start=load_prune)
     load_org = wifire_nabuorg(start=load_prov)
 
-    summarize = wifire_summarize(start=load_uploadrelease)
-    upload_summarize = wifire_upload_summarize(start=summarize)
+    if(GLEANERIO_SUMMARIZE_GRAPH):
+        summarize = wifire_summarize(start=load_uploadrelease)
+        upload_summarize = wifire_upload_summarize(start=summarize)
+
+
 
 # run after load
-    report_msgraph = wifire_missingreport_graph(start=summarize)
+    report_msgraph = wifire_missingreport_graph(start=load_prov)
     report_graph = wifire_graph_reports(start=report_msgraph)
 
 

--- a/dagster/implnets/requirements.txt
+++ b/dagster/implnets/requirements.txt
@@ -10,8 +10,8 @@ advertools==0.13.2
 minio==7.1.13
 docker>=6.1.0
 
-earthcube-utilities>=0.1.18
-#earthcube-utilities @ git+https://github.com/earthcube/earthcube_utilities@b671efb#subdirectory=earthcube_utilities
+#earthcube-utilities>=0.1.18
+earthcube-utilities @ git+https://github.com/earthcube/earthcube_utilities@ebc7717#subdirectory=earthcube_utilities
 # if we want to use an non-released branch 2c1dcab is the commit
 # earthcube-utilities @ git+https://github.com/earthcube/earthcube_utilities@2c1dcab#subdirectory=earthcube_utilities
 

--- a/dagster/implnets/templates/v1/implnet_ops_SOURCEVAL.py
+++ b/dagster/implnets/templates/v1/implnet_ops_SOURCEVAL.py
@@ -12,10 +12,12 @@ from docker.types import RestartPolicy, ServiceMode
 from ec.gleanerio.gleaner import getGleaner, getSitemapSourcesFromGleaner, endpointUpdateNamespace
 import json
 
+from ec.graph.release_graph import ReleaseGraph
 from minio import Minio
 from minio.error import S3Error
 from datetime import datetime
-from ec.reporting.report import missingReport, generateGraphReportsRepo, reportTypes, generateIdentifierRepo
+from ec.reporting.report import missingReport, generateGraphReportsRepo, reportTypes, generateIdentifierRepo, \
+    generateGraphReportsRelease
 from ec.datastore import s3
 from ec.summarize import summaryDF2ttl, get_summary4graph, get_summary4repoSubset
 from ec.graph.manageGraph import ManageBlazegraph as mg
@@ -81,6 +83,7 @@ GLEANERIO_GLEANER_DOCKER_CONFIG=str(os.environ.get('GLEANERIO_GLEANER_DOCKER_CON
 GLEANERIO_NABU_DOCKER_CONFIG=str(os.environ.get('GLEANERIO_NABU_DOCKER_CONFIG', 'nabu'))
 #GLEANERIO_SUMMARY_GRAPH_ENDPOINT = os.environ.get('GLEANERIO_SUMMARY_GRAPH_ENDPOINT')
 GLEANERIO_SUMMARY_GRAPH_NAMESPACE = os.environ.get('GLEANERIO_SUMMARY_GRAPH_NAMESPACE',f"{GLEANER_GRAPH_NAMESPACE}_summary" )
+GLEANERIO_SUMMARIZE_GRAPH=(os.getenv('GLEANERIO_SUMMARIZE_GRAPH', 'False').lower()  == 'true')
 
 SUMMARY_PATH = 'graphs/summary'
 RELEASE_PATH = 'graphs/latest'
@@ -174,17 +177,28 @@ def s3loader(data, name):
                       content_type="text/plain"
                          )
     get_dagster_logger().info(f"Log uploaded: {str(objPrefix)}")
-def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_graphEndpoint()):
-    # revision of EC utilities, will have a insertFromURL
-    #instance =  mg.ManageBlazegraph(os.environ.get('GLEANER_GRAPH_URL'),os.environ.get('GLEANER_GRAPH_NAMESPACE') )
-    proto = "http"
 
+def _releaseUrl( source, path=RELEASE_PATH, extension="nq"):
+    proto = "http"
     if GLEANER_MINIO_USE_SSL:
         proto = "https"
-    port = GLEANER_MINIO_PORT
     address = _pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT)
     bucket = GLEANER_MINIO_BUCKET
     release_url = f"{proto}://{address}/{bucket}/{path}/{source}_release.{extension}"
+    return release_url
+
+def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_graphEndpoint()):
+    # revision of EC utilities, will have a insertFromURL
+    #instance =  mg.ManageBlazegraph(os.environ.get('GLEANER_GRAPH_URL'),os.environ.get('GLEANER_GRAPH_NAMESPACE') )
+    # proto = "http"
+    #
+    # if GLEANER_MINIO_USE_SSL:
+    #     proto = "https"
+    # port = GLEANER_MINIO_PORT
+    # address = _pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT)
+    # bucket = GLEANER_MINIO_BUCKET
+    # release_url = f"{proto}://{address}/{bucket}/{path}/{source}_release.{extension}"
+
     # BLAZEGRAPH SPECIFIC
     # url = f"{_graphEndpoint()}?uri={release_url}"  # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql?uri={release_url}"
     # get_dagster_logger().info(f'graph: insert "{source}" to {url} ')
@@ -201,6 +215,7 @@ def post_to_graph(source, path=RELEASE_PATH, extension="nq", graphendpoint=_grap
     #     get_dagster_logger().info(f'graph: error')
     #     raise Exception(f' graph: insert failed: status:{r.status_code}')
 
+    release_url = _releaseUrl(source, path, extension)
     ### GENERIC LOAD FROM
     url = f"{graphendpoint}" # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql?uri={release_url}"
     get_dagster_logger().info(f'graph: insert "{source}" to {url} ')
@@ -685,9 +700,10 @@ def SOURCEVAL_graph_reports(context) :
 
     graphendpoint = _graphEndpoint() # f"{os.environ.get('GLEANER_GRAPH_URL')}/namespace/{os.environ.get('GLEANER_GRAPH_NAMESPACE')}/sparql"
 
-    milled = False
-    summon = True
-    returned_value = generateGraphReportsRepo(source_name,  graphendpoint, reportList=reportTypes["repo_detailed"])
+
+    #returned_value = generateGraphReportsRepo(source_name,  graphendpoint, reportList=reportTypes["repo_detailed"])
+    s3FileUrl = _releaseUrl(source_name )
+    returned_value = generateGraphReportsRelease(source_name,s3FileUrl)
     r = str('returned value:{}'.format(returned_value))
     #report = json.dumps(returned_value, indent=2) # value already json.dumps
     report = returned_value
@@ -738,7 +754,13 @@ def SOURCEVAL_summarize(context) :
 
     try:
 
-        summarydf = get_summary4repoSubset(endpoint, source_name)
+       # summarydf = get_summary4repoSubset(endpoint, source_name)
+        rg = ReleaseGraph()
+        rg.read_release(_pythonMinioAddress(GLEANER_MINIO_ADDRESS, GLEANER_MINIO_PORT),
+                        bucket,
+                        source_name,
+                        options=MINIO_OPTIONS)
+        summarydf = rg.summarize()
         nt, g = summaryDF2ttl(summarydf, source_name)  # let's try the new generator
         summaryttl = g.serialize(format='longturtle')
         # Lets always write out file to s3, and insert as a separate process
@@ -791,10 +813,11 @@ def harvest_SOURCEVAL():
 # defingin nothing dependencies
     # https://docs.dagster.io/concepts/ops-jobs-graphs/graphs#defining-nothing-dependencies
 
-    report_ms3 = SOURCEVAL_missingreport_s3(start=harvest)
+    report_bucketurl = SOURCEVAL_bucket_urls(start=harvest)
+    report_ms3 = SOURCEVAL_missingreport_s3(start=report_bucketurl)
     report_idstat = SOURCEVAL_identifier_stats(start=report_ms3)
     # for some reason, this causes a msg parameter missing
-    report_bucketurl = SOURCEVAL_bucket_urls(start=report_idstat)
+
 
     #report1 = missingreport_s3(harvest, source="SOURCEVAL")
     load_release = SOURCEVAL_naburelease(start=harvest)
@@ -804,11 +827,14 @@ def harvest_SOURCEVAL():
     load_prov = SOURCEVAL_nabuprov(start=load_prune)
     load_org = SOURCEVAL_nabuorg(start=load_prov)
 
-    summarize = SOURCEVAL_summarize(start=load_uploadrelease)
-    upload_summarize = SOURCEVAL_upload_summarize(start=summarize)
+    if(GLEANERIO_SUMMARIZE_GRAPH):
+        summarize = SOURCEVAL_summarize(start=load_uploadrelease)
+        upload_summarize = SOURCEVAL_upload_summarize(start=summarize)
+
+
 
 # run after load
-    report_msgraph = SOURCEVAL_missingreport_graph(start=summarize)
+    report_msgraph = SOURCEVAL_missingreport_graph(start=load_prov)
     report_graph = SOURCEVAL_graph_reports(start=report_msgraph)
 
 


### PR DESCRIPTION
The uses the release files to generate the graph summary reports.
the missing reports still need to directly access the triplestore, since we want to know what made it into the triple store.

using a commit reference to get the appropriate earthcube utilities

