### PR TITLE
Replace distutils.util.strtobool for Python 3.12

### DIFF
--- a/dagster/implnets/templates/v1.iow/implnet_ops_SOURCEVAL.py
+++ b/dagster/implnets/templates/v1.iow/implnet_ops_SOURCEVAL.py
@@ -1,4 +1,3 @@
-import distutils
 import time
 
 from dagster import job, op, graph,In, Nothing, get_dagster_logger
@@ -49,7 +48,19 @@ APIKEY = os.environ.get('PORTAINER_KEY')
 
 GLEANER_MINIO_ADDRESS = str(os.environ.get('GLEANERIO_MINIO_ADDRESS'))
 GLEANER_MINIO_PORT = str(os.environ.get('GLEANERIO_MINIO_PORT'))
-GLEANER_MINIO_USE_SSL = bool(distutils.util.strtobool(os.environ.get('GLEANERIO_MINIO_USE_SSL')))
+def strtobool(val):
+    """Convert a string representation of truth to 1 (true) or 0 (false).
+
+    Replacement for distutils.util.strtobool, removed in Python 3.12.
+    """
+    val = str(val).lower()
+    if val in ("y", "yes", "t", "true", "on", "1"):
+        return 1
+    if val in ("n", "no", "f", "false", "off", "0"):
+        return 0
+    raise ValueError(f"invalid truth value {val!r}")
+
+GLEANER_MINIO_USE_SSL = bool(strtobool(os.environ.get('GLEANERIO_MINIO_USE_SSL')))
 GLEANER_MINIO_SECRET_KEY = str(os.environ.get('GLEANERIO_MINIO_SECRET_KEY'))
 GLEANER_MINIO_ACCESS_KEY = str(os.environ.get('GLEANERIO_MINIO_ACCESS_KEY'))
 GLEANER_MINIO_BUCKET =str( os.environ.get('GLEANERIO_MINIO_BUCKET'))
@@ -141,7 +152,7 @@ def s3loader(data, name):
     client = Minio(
         server,
         secure=secure,
-        #secure = bool(distutils.util.strtobool(os.environ.get('GLEANER_MINIO_SSL'))),
+        #secure = bool(strtobool(os.environ.get('GLEANER_MINIO_SSL'))),
         access_key=GLEANER_MINIO_ACCESS_KEY,
         secret_key=GLEANER_MINIO_SECRET_KEY,
     )

--- a/dagster/implnets/templates/v1/implnet_ops_SOURCEVAL.py
+++ b/dagster/implnets/templates/v1/implnet_ops_SOURCEVAL.py
@@ -1,5 +1,4 @@
 import csv
-import distutils
 import logging
 import time
 
@@ -56,7 +55,19 @@ CONTAINER_WAIT_TIMEOUT= int( os.environ.get('GLEANERIO_DOCKER_CONTAINER_WAIT_TIM
 
 GLEANER_MINIO_ADDRESS = str(os.environ.get('GLEANERIO_MINIO_ADDRESS'))
 GLEANER_MINIO_PORT = str(os.environ.get('GLEANERIO_MINIO_PORT'))
-GLEANER_MINIO_USE_SSL = bool(distutils.util.strtobool(os.environ.get('GLEANERIO_MINIO_USE_SSL')))
+def strtobool(val):
+    """Convert a string representation of truth to 1 (true) or 0 (false).
+
+    Replacement for distutils.util.strtobool, removed in Python 3.12.
+    """
+    val = str(val).lower()
+    if val in ("y", "yes", "t", "true", "on", "1"):
+        return 1
+    if val in ("n", "no", "f", "false", "off", "0"):
+        return 0
+    raise ValueError(f"invalid truth value {val!r}")
+
+GLEANER_MINIO_USE_SSL = bool(strtobool(os.environ.get('GLEANERIO_MINIO_USE_SSL')))
 GLEANER_MINIO_SECRET_KEY = str(os.environ.get('GLEANERIO_MINIO_SECRET_KEY'))
 GLEANER_MINIO_ACCESS_KEY = str(os.environ.get('GLEANERIO_MINIO_ACCESS_KEY'))
 GLEANER_MINIO_BUCKET =str( os.environ.get('GLEANERIO_MINIO_BUCKET'))
@@ -151,7 +162,7 @@ def s3_log_uploader(data, name, date_string=datetime.now().strftime("%Y_%m_%d_%H
     client = Minio(
         server,
         secure=secure,
-        #secure = bool(distutils.util.strtobool(os.environ.get('GLEANER_MINIO_SSL'))),
+        #secure = bool(strtobool(os.environ.get('GLEANER_MINIO_SSL'))),
         access_key=GLEANER_MINIO_ACCESS_KEY,
         secret_key=GLEANER_MINIO_SECRET_KEY,
     )

--- a/dagster/implnets/workflows/ecrr/ecrr/ops/implnet_ops_ecrr_examples.py
+++ b/dagster/implnets/workflows/ecrr/ecrr/ops/implnet_ops_ecrr_examples.py
@@ -1,4 +1,4 @@
-from distutils import util
+from ..utils import strtobool
 import logging
 import time
 
@@ -52,7 +52,7 @@ APIKEY = os.environ.get('GLEANERIO_PORTAINER_APIKEY')
 
 GLEANER_MINIO_ADDRESS = str(os.environ.get('GLEANERIO_MINIO_ADDRESS'))
 GLEANER_MINIO_PORT = str(os.environ.get('GLEANERIO_MINIO_PORT'))
-GLEANER_MINIO_USE_SSL = bool(util.strtobool(os.environ.get('GLEANERIO_MINIO_USE_SSL')))
+GLEANER_MINIO_USE_SSL = bool(strtobool(os.environ.get('GLEANERIO_MINIO_USE_SSL')))
 GLEANER_MINIO_SECRET_KEY = str(os.environ.get('GLEANERIO_MINIO_SECRET_KEY'))
 GLEANER_MINIO_ACCESS_KEY = str(os.environ.get('GLEANERIO_MINIO_ACCESS_KEY'))
 GLEANER_MINIO_BUCKET =str( os.environ.get('ECRR_MINIO_BUCKET'))
@@ -146,7 +146,7 @@ def s3loader(data, name):
     client = Minio(
         server,
         secure=secure,
-        #secure = bool(distutils.util.strtobool(os.environ.get('GLEANER_MINIO_SSL'))),
+        #secure = bool(strtobool(os.environ.get('GLEANER_MINIO_SSL'))),
         access_key=GLEANER_MINIO_ACCESS_KEY,
         secret_key=GLEANER_MINIO_SECRET_KEY,
     )

--- a/dagster/implnets/workflows/ecrr/ecrr/ops/implnet_ops_ecrr_submitted.py
+++ b/dagster/implnets/workflows/ecrr/ecrr/ops/implnet_ops_ecrr_submitted.py
@@ -1,4 +1,4 @@
-from distutils import util
+from ..utils import strtobool
 import logging
 import time
 
@@ -52,7 +52,7 @@ APIKEY = os.environ.get('GLEANERIO_PORTAINER_APIKEY')
 
 GLEANER_MINIO_ADDRESS = str(os.environ.get('GLEANERIO_MINIO_ADDRESS'))
 GLEANER_MINIO_PORT = str(os.environ.get('GLEANERIO_MINIO_PORT'))
-GLEANER_MINIO_USE_SSL = bool(util.strtobool(os.environ.get('GLEANERIO_MINIO_USE_SSL')))
+GLEANER_MINIO_USE_SSL = bool(strtobool(os.environ.get('GLEANERIO_MINIO_USE_SSL')))
 GLEANER_MINIO_SECRET_KEY = str(os.environ.get('GLEANERIO_MINIO_SECRET_KEY'))
 GLEANER_MINIO_ACCESS_KEY = str(os.environ.get('GLEANERIO_MINIO_ACCESS_KEY'))
 GLEANER_MINIO_BUCKET =str( os.environ.get('ECRR_MINIO_BUCKET'))
@@ -146,7 +146,7 @@ def s3loader(data, name):
     client = Minio(
         server,
         secure=secure,
-        #secure = bool(distutils.util.strtobool(os.environ.get('GLEANER_MINIO_SSL'))),
+        #secure = bool(strtobool(os.environ.get('GLEANER_MINIO_SSL'))),
         access_key=GLEANER_MINIO_ACCESS_KEY,
         secret_key=GLEANER_MINIO_SECRET_KEY,
     )

--- a/dagster/implnets/workflows/ecrr/ecrr/utils.py
+++ b/dagster/implnets/workflows/ecrr/ecrr/utils.py
@@ -1,0 +1,11 @@
+def strtobool(val):
+    """Convert a string representation of truth to 1 (true) or 0 (false).
+
+    Replacement for distutils.util.strtobool, which was removed in Python 3.12.
+    """
+    val = str(val).lower()
+    if val in ("y", "yes", "t", "true", "on", "1"):
+        return 1
+    if val in ("n", "no", "f", "false", "off", "0"):
+        return 0
+    raise ValueError(f"invalid truth value {val!r}")

--- a/dagster/implnets/workflows/tasks/tasks/__init__.py
+++ b/dagster/implnets/workflows/tasks/tasks/__init__.py
@@ -1,5 +1,4 @@
 import os
-from distutils.util import strtobool
 from dagster import Definitions, load_assets_from_modules, EnvVar,RunFailureSensorContext
 from dagster_aws.s3 import  S3Resource
 #from dagster_slack import SlackResource, make_slack_on_run_failure_sensor

--- a/dagster/implnets/workflows/tasks/tasks/assets/all_graph_stats.py
+++ b/dagster/implnets/workflows/tasks/tasks/assets/all_graph_stats.py
@@ -1,4 +1,3 @@
-from distutils import util
 import json
 import os
 
@@ -15,7 +14,7 @@ log = config_app()
 PROJECT=os.environ.get('PROJECT')
 # GLEANERIO_MINIO_ADDRESS = str(os.environ.get('GLEANERIO_MINIO_ADDRESS'))
 # GLEANERIO_MINIO_PORT = str(os.environ.get('GLEANERIO_MINIO_PORT'))
-# GLEANERIO_MINIO_USE_SSL = bool(util.strtobool(os.environ.get('GLEANERIO_MINIO_USE_SSL', 'true')))
+# GLEANERIO_MINIO_USE_SSL = bool(strtobool(os.environ.get('GLEANERIO_MINIO_USE_SSL', 'true')))
 # GLEANERIO_MINIO_SECRET_KEY = str(os.environ.get('GLEANERIO_MINIO_SECRET_KEY'))
 # GLEANERIO_MINIO_ACCESS_KEY = str(os.environ.get('GLEANERIO_MINIO_ACCESS_KEY'))
 # GLEANER_MINIO_BUCKET =str( os.environ.get('GLEANERIO_MINIO_BUCKET'))

--- a/dagster/implnets/workflows/tasks/tasks/assets/source_stats.py
+++ b/dagster/implnets/workflows/tasks/tasks/assets/source_stats.py
@@ -1,4 +1,3 @@
-import distutils
 import json
 import os
 from typing import List, Any
@@ -6,11 +5,11 @@ import pandas as pd
 from dagster import asset, get_dagster_logger, define_asset_job, AutoMaterializePolicy
 from ec.datastore import s3
 from pydash import pick
-from distutils import util
+from ..utils import strtobool
 PROJECT=os.environ.get('PROJECT')
 GLEANER_MINIO_ADDRESS = os.environ.get('GLEANERIO_MINIO_ADDRESS')
 GLEANER_MINIO_PORT = os.environ.get('GLEANERIO_MINIO_PORT')
-GLEANER_MINIO_USE_SSL = bool(util.strtobool(os.environ.get('GLEANERIO_MINIO_USE_SSL', 'true')))
+GLEANER_MINIO_USE_SSL = bool(strtobool(os.environ.get('GLEANERIO_MINIO_USE_SSL', 'true')))
 GLEANER_MINIO_SECRET_KEY = os.environ.get('GLEANERIO_MINIO_SECRET_KEY')
 GLEANER_MINIO_ACCESS_KEY = os.environ.get('GLEANERIO_MINIO_ACCESS_KEY')
 GLEANER_MINIO_BUCKET = os.environ.get('GLEANERIO_MINIO_BUCKET')

--- a/dagster/implnets/workflows/tasks/tasks/assets/tenants.py
+++ b/dagster/implnets/workflows/tasks/tasks/assets/tenants.py
@@ -16,14 +16,14 @@ from dagster import (asset,
                      asset_sensor, AssetKey, AutoMaterializePolicy,
                      )
 from ec.datastore import s3
-from distutils import util
+from ..utils import strtobool
 from ..resources.gleanerS3 import _pythonMinioAddress
 from ec.reporting.report import generateReportStats
 
 PROJECT=os.environ.get('PROJECT')
 GLEANER_MINIO_ADDRESS = os.environ.get('GLEANERIO_MINIO_ADDRESS')
 GLEANER_MINIO_PORT = os.environ.get('GLEANERIO_MINIO_PORT')
-GLEANER_MINIO_USE_SSL = bool(util.strtobool(os.environ.get('GLEANERIO_MINIO_USE_SSL', 'true')))
+GLEANER_MINIO_USE_SSL = bool(strtobool(os.environ.get('GLEANERIO_MINIO_USE_SSL', 'true')))
 GLEANER_MINIO_SECRET_KEY = os.environ.get('GLEANERIO_MINIO_SECRET_KEY')
 GLEANER_MINIO_ACCESS_KEY = os.environ.get('GLEANERIO_MINIO_ACCESS_KEY')
 GLEANER_MINIO_BUCKET = os.environ.get('GLEANERIO_MINIO_BUCKET')

--- a/dagster/implnets/workflows/tasks/tasks/utils.py
+++ b/dagster/implnets/workflows/tasks/tasks/utils.py
@@ -1,0 +1,11 @@
+def strtobool(val):
+    """Convert a string representation of truth to 1 (true) or 0 (false).
+
+    Replacement for distutils.util.strtobool, which was removed in Python 3.12.
+    """
+    val = str(val).lower()
+    if val in ("y", "yes", "t", "true", "on", "1"):
+        return 1
+    if val in ("n", "no", "f", "false", "off", "0"):
+        return 0
+    raise ValueError(f"invalid truth value {val!r}")


### PR DESCRIPTION
## Problem

The tasks code server crashes on startup under Python 3.12:

```
File "/usr/src/app/workflows/tasks/tasks/__init__.py", line 2, in <module>
    from distutils.util import strtobool
ModuleNotFoundError: No module named 'distutils'
```

`distutils` was removed from the standard library in Python 3.12.

## Change

- Add a local `strtobool()` helper in `workflows/tasks/tasks/utils.py` and `workflows/ecrr/ecrr/utils.py`, and point all callers at it.
- Drop the unused `from distutils.util import strtobool` from `workflows/tasks/tasks/__init__.py` (the actual crash).
- Inline the same helper in `templates/v1/implnet_ops_SOURCEVAL.py` and `templates/v1.iow/implnet_ops_SOURCEVAL.py` — generated code has no shared module to import from.
- Fix up commented-out `distutils` references so they don't get copy-pasted back in.

An AST scan over the repo confirms no `distutils` imports remain.

## Note

The running container still needs a rebuild (`cd dagster/implnets && make wf-build`) — the traceback above came from a stale image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)