### PR TITLE
Speed up the container builds: 14 min -> ~2.5 min

### DIFF
--- a/.github/workflows/contanerize.yaml
+++ b/.github/workflows/contanerize.yaml
@@ -17,8 +17,12 @@ on:
       - dev_eco
       - v0_generated_code
       - 173_dev_graphreport
+      # TEMPORARY: so this branch can be timed before merging. remove before merge.
+      - perf/faster-docker-builds
     tags:
       - "v*.*.*"
+  # so a build can be kicked off by hand on any branch
+  workflow_dispatch:
 
 # https://github.com/marketplace/actions/publish-docker
 # https://github.com/docker/build-push-action

--- a/.github/workflows/contanerize.yaml
+++ b/.github/workflows/contanerize.yaml
@@ -17,8 +17,6 @@ on:
       - dev_eco
       - v0_generated_code
       - 173_dev_graphreport
-      # TEMPORARY: so this branch can be timed before merging. remove before merge.
-      - perf/faster-docker-builds
     tags:
       - "v*.*.*"
   # so a build can be kicked off by hand on any branch

--- a/.github/workflows/contanerize.yaml
+++ b/.github/workflows/contanerize.yaml
@@ -2,6 +2,11 @@ name: Dockerize  Dagster
 # this will build based on what is committed to the branch
 # dockerbuildandpush pulls the repo.
 # overwrites any files created.
+#
+# Each arch builds on a runner of that arch and pushes by digest; the merge job
+# stitches the digests into one multi-arch tag. arm64 used to be cross-built on
+# an amd64 runner under QEMU, which emulates every instruction of the dependency
+# install and dominated the build time.
 on:
   push:
     # be wary of using **  for the branch...
@@ -23,36 +28,102 @@ defaults:
 
 jobs:
   build:
-    name: Dockerize  Scheduler
-    runs-on: ubuntu-latest
-    #strategy:
-      #matrix:
-       # project: [ "eco" ]
-        #project: [ "eco", "iow", "oih" ]
-       # platform: ["linux/amd64","linux/arm64"]
-        #platform: ["linux/amd64"] #linux/arm64 issues with building
+    name: ${{ matrix.name }} (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: dagster
+            image: nsfearthcube/dagster-gleanerio
+            file: ./build/Dockerfile_dagster
+            arch: amd64
+            runner: ubuntu-latest
+          - name: dagster
+            image: nsfearthcube/dagster-gleanerio
+            file: ./build/Dockerfile_dagster
+            arch: arm64
+            runner: ubuntu-24.04-arm
+          - name: workflows
+            image: nsfearthcube/dagster-gleanerio-workflows
+            file: ./build/Dockerfile_workflows
+            arch: amd64
+            runner: ubuntu-latest
+          - name: workflows
+            image: nsfearthcube/dagster-gleanerio-workflows
+            file: ./build/Dockerfile_workflows
+            arch: arm64
+            runner: ubuntu-24.04-arm
     steps:
-      - name: Set variables
-        run: |
-            REGISTRY_IMAGE=nsfearthcube/dagster-gleanerio
-            echo "REGISTRY_IMAGE=$REGISTRY_IMAGE" >> $GITHUB_ENV
-        working-directory:  /
-      - name: Checkout Repo
-        uses: actions/checkout@v3
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Extract metadata (tags, labels) for Docker
+      - name: Extract metadata (labels) for Docker
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
-          images:  ${{ env.REGISTRY_IMAGE }}
+          images: ${{ matrix.image }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          #context:  ./dagster/implnets
+          # grr https://github.com/docker/build-push-action#git-context
+          file: ${{ matrix.file }}
+          context:  "{{defaultContext}}:dagster/implnets"
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/${{ matrix.arch }}
+          # a run that does not touch pyproject.toml/uv.lock reuses the whole
+          # dependency layer instead of resolving and downloading it again
+          cache-from: type=gha,scope=${{ matrix.name }}-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.name }}-${{ matrix.arch }}
+          outputs: type=image,name=${{ matrix.image }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+        working-directory: /
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.name }}-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: Merge ${{ matrix.name }} manifest
+    runs-on: ubuntu-latest
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: dagster
+            image: nsfearthcube/dagster-gleanerio
+          - name: workflows
+            image: nsfearthcube/dagster-gleanerio-workflows
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          pattern: digests-${{ matrix.name }}-*
+          merge-multiple: true
+          path: /tmp/digests
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Extract metadata (tags) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ matrix.image }}
           flavor: |
             latest=true
           tags: |
@@ -60,83 +131,16 @@ jobs:
             type=ref,event=branch
             type=semver,pattern={{version}}
             type=sha
-
-      - name: Build and push
-        id: build
-        uses: docker/build-push-action@v6
-        with:
-          #context:  ./dagster/implnets
-          # grr https://github.com/docker/build-push-action#git-context
-          #context:  "{{defaultContext}}"
-          push: true
-          build-args:
-            implnet=${{ matrix.project }}
-          #file: ./dagster/implnets/build/Dockerfile
-          file: ./build/Dockerfile_dagster
-          context:  "{{defaultContext}}:dagster/implnets"
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
-          #outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
-
-      - name: Image digest
-        run: echo ${{ steps.build.outputs.digest }}
-
-  build_code_workflows:
-    name: Dockerize  Scheduler Workflows base
-    runs-on: ubuntu-latest
-    #strategy:
-      #matrix:
-       # project: [ "eco" ]
-        #project: [ "eco", "iow", "oih" ]
-        #platform: ["linux/amd64","linux/arm64"]
-        #platform: ["linux/amd64"] #linux/arm64 issues with building
-    steps:
-      - name: Set variables
-        run: |
-            REGISTRY_IMAGE=nsfearthcube/dagster-gleanerio-workflows
-            echo "REGISTRY_IMAGE=$REGISTRY_IMAGE" >> $GITHUB_ENV
-        working-directory:  /
-      - name: Checkout Repo
-        uses: actions/checkout@v3
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v4
-        with:
-          images:  ${{ env.REGISTRY_IMAGE }}
-          flavor: |
-            latest=true
-          tags: |
-            type=ref,event=tag
-            type=ref,event=branch
-            type=semver,pattern={{version}}
-            type=sha
-      - name: Build and push
-        id: build
-        uses: docker/build-push-action@v6
-        with:
-          #context:  ./dagster/implnets
-          # grr https://github.com/docker/build-push-action#git-context
-          #context:  "{{defaultContext}}"
-          push: true
-          build-args:
-            implnet=${{ matrix.project }}
-          #file: ./dagster/implnets/build/Dockerfile
-          file: ./build/Dockerfile_workflows
-          context:  "{{defaultContext}}:dagster/implnets"
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
-          #outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
-
-      - name: Image digest
-        run: echo ${{ steps.build.outputs.digest }}
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ matrix.image }}@sha256:%s ' *)
+      - name: Inspect image
+        run: echo "${{ matrix.image }}:${{ steps.meta.outputs.version }}" && docker buildx imagetools inspect ${{ matrix.image }}:${{ steps.meta.outputs.version }}
+        working-directory: /

--- a/dagster/implnets/.dockerignore
+++ b/dagster/implnets/.dockerignore
@@ -1,0 +1,14 @@
+# the local build (make wf-build) uses . as its context, which otherwise ships
+# ~1GB of venv and harvested data to the daemon before the build even starts.
+.venv
+.tmp_dagster_home_*
+__pycache__/
+*.pyc
+
+generatedCode/
+workflows/*/data/
+workflows/**/*.log
+tests/
+
+.git
+.idea

--- a/dagster/implnets/build/Dockerfile_dagster
+++ b/dagster/implnets/build/Dockerfile_dagster
@@ -6,13 +6,16 @@ FROM python:3.12-slim
 # this fails becaus the dagster/implnets files are not in the docker
 
 
-RUN pip install --upgrade pip
+# the uv binary straight from its image, so we skip a pip resolve+install just
+# to get the tool that does the resolving
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+
 ## this is a base for the project. Build this 'layer' first
 ## only the dagster core packages, from the 'dagster' group in pyproject.toml
 COPY ./pyproject.toml ./uv.lock ./
-RUN pip install uv \
-    && uv export --frozen --only-group dagster --no-emit-project -o /tmp/requirements.txt \
-    && pip install -r /tmp/requirements.txt
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv export --frozen --only-group dagster --no-emit-project -o /tmp/requirements.txt \
+    && uv pip install --system -r /tmp/requirements.txt
 
 ## this add the code
 #COPY . scheduler

--- a/dagster/implnets/build/Dockerfile_workflows
+++ b/dagster/implnets/build/Dockerfile_workflows
@@ -1,14 +1,19 @@
 FROM python:3.12-slim
 
-
 # this file no longer needs to generate code. It will just include the base
 # it will run ingest by default
 # we may want to get an unreleased version of code, so this is needed
 
-RUN apt-get update && apt-get install -y git \
-    && apt-get install -y  gcc musl-dev python3-dev
-RUN pip install uv \
-    && pip install --upgrade pip#RUN apt-get install libffi-dev
+# the uv binary straight from its image, so we skip a pip resolve+install just
+# to get the tool that does the resolving
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+
+# git: earthcube-utilities is a git dependency.
+# gcc/python3-dev: for any sdist-only dependency without a wheel for this arch.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git gcc python3-dev \
+    && rm -rf /var/lib/apt/lists/*
+
 # Read the ARG implnet to set who to build for.
 
 # docker buildandpush pulls the repo, so we need to put the code at a different location
@@ -22,11 +27,10 @@ RUN mkdir -p /usr/src/app/workflows
 ## deps come from pyproject.toml, pinned by uv.lock
 ## --no-hashes: earthcube-utilities is a git dependency and cannot be hashed,
 ## and pip refuses a requirements file that mixes hashed and unhashed entries.
-# --no-hashes: earthcube-utilities is a git dependency and cannot be hashed,
-# and pip refuses a requirements file that mixes hashed and unhashed entries.
 COPY ./pyproject.toml ./uv.lock ./
-RUN uv export --frozen --no-dev --no-hashes --no-emit-project -o /tmp/requirements.txt \
-    && pip install -r /tmp/requirements.txt
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv export --frozen --no-dev --no-hashes --no-emit-project -o /tmp/requirements.txt \
+    && uv pip install --system -r /tmp/requirements.txt
 
 # this add the code
 COPY . scheduler


### PR DESCRIPTION
## Measured

Both timings are from real runs on this branch (multi-arch manifests published correctly in both).

| | before | cold cache | warm cache |
|---|---|---|---|
| workflows image | 14 min | 1.9 min | 0.4 min |
| dagster image | 8 min | 1.4 min | 0.4 min |
| **total wall clock** | ~14 min | **2.6 min** ([run](https://github.com/earthcube/scheduler/actions/runs/31145454217)) | **1.1 min** ([run](https://github.com/earthcube/scheduler/actions/runs/31145618665)) |

A typical push lands between the two — source changes invalidate the layers after the dependency install, but those are just file copies. Expect the ~2.6 min number only when `pyproject.toml` / `uv.lock` change.

## What was slow

**1. arm64 was cross-built under QEMU.** `platforms: linux/amd64,linux/arm64` on an amd64 runner meant every instruction of the arm64 dependency install was emulated. This was most of the 14 and 8 minutes. Each arch now builds on a runner of its own arch (`ubuntu-24.04-arm` is free on public repos) and pushes by digest; a merge job stitches the digests into one multi-arch tag, so the published tags are unchanged. All four builds run in parallel. This is the push-by-digest pattern the disabled `contanerize_multi.yaml_` already sketched.

arm64 is now *faster* than amd64 for the dagster image, which shows how much the emulation was costing.

**2. No build cache at all.** Every run reinstalled every dependency from scratch. Added `cache-from`/`cache-to: type=gha,mode=max`, scoped per image and arch.

**3. Slower-than-necessary installs.** `pip install uv` (a full pip resolve just to obtain uv) replaced with `COPY --from=ghcr.io/astral-sh/uv:latest`; `pip install -r` replaced with `uv pip install --system -r`; a cache mount on uv's cache dir. In `Dockerfile_workflows` the apt layers collapse into one with `--no-install-recommends` and a lists cleanup. Dropped `musl-dev`, which does nothing in a glibc `python:3.12-slim` image.

## Also in here

- **Fixes a broken `dev`.** #194 glued the `#RUN apt-get install libffi-dev` comment onto a `\` continuation line, so it became part of the shell command and the workflows image has not built since:
  ```
  ERROR: Invalid requirement: 'pip#RUN': Expected end or semicolon
  ```
  Rewriting that block removes the broken line.
- `workflow_dispatch:`, so a build can be kicked off by hand on any branch. Verified working.
- `dagster/implnets/.dockerignore` — `make wf-build` locally uses `.` as its context and was shipping the 629M `.venv` and 292M of harvested data to the daemon before the build started. No effect on CI, which uses a git context.
- Bumped the pinned actions (`login@v2`->`v3`, `metadata@v4`->`v5`, `upload-artifact@v3`->`v4`). v3 artifacts are retired, so the digest-merge pattern would not have worked on the old pins.
- Dropped `actions/checkout` from the build jobs: with `context: "{{defaultContext}}:dagster/implnets"` buildkit clones the repo itself and the checked-out tree was never read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)